### PR TITLE
fix: eliminate verse double-spacing in Live Preview and inline style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+All notable changes to Bible Verse are documented here.
+
+## [1.6.3] — Unreleased
+
+### Fixed
+
+- **Verse double-spacing in Live Preview** — Verses in `nl` mode were rendering with a blank line between each verse in Live Preview (edit mode) while appearing correctly in reading mode. Root cause: CodeMirror 6's editor inherits `white-space: pre-wrap` into rendered content, causing the whitespace text nodes that Obsidian's markdown renderer emits after each `<br>` to render as real line breaks. Fixed by explicitly setting `white-space: normal` on the verse body container.
+- **Inline style line breaks** — `{ref, inline}` displayed verses on separate lines instead of as continuous quoted text, in both reading mode and Live Preview. Root cause: `<br>` elements from the markdown renderer were left in place after paragraph unwrapping. Fixed by replacing `<br>` with a space in the inline rendering path.
+
+## [1.6.2] — 2026-05-20
+
+### Added
+
+- Reading sections (`para` mode) — display a full chapter with paragraph groupings preserved, matching the structure of the original text
+- IntelliSense helper mode — after accepting a verse suggestion, a follow-up menu offers common modifiers (callout, sidebar, verse numbers, etc.)
+- Inline syntax examples and collapsible quick-reference in the settings tab
+
+### Fixed
+
+- KJV pilcrow (`¶`) character stripped before verse-number prepend to prevent broken line breaks
+- Paragraph spacing normalised across inline and block display styles
+- Verse number list markers escaped so `1.` is not misread as a markdown ordered list
+
+## [1.6.0] — 2026-04-25
+
+### Added
+
+- Initial public release prepared for Obsidian community plugin submission
+- Inline `{ref}` syntax with support for translation override, style override, verse numbers, and new-line-per-verse flags
+- Display styles: callout, sidebar, blockquote, inline
+- Side-by-side translation comparison (`{ref, KJV | NIV}`)
+- Baked verse text via `Bake` and `Refresh` commands
+- Verse cache with optional persistence
+- Quick Insert command palette modal
+- Settings tab with per-option syntax examples

--- a/main.js
+++ b/main.js
@@ -1423,6 +1423,13 @@ async function renderText(el, text, app, component, isInline = false) {
       }
       p.remove();
     }
+    for (const br of Array.from(container.querySelectorAll("br"))) {
+      const next = br.nextSibling;
+      if ((next == null ? void 0 : next.nodeType) === Node.TEXT_NODE && next.data.startsWith("\n")) {
+        next.data = next.data.slice(1);
+      }
+      br.replaceWith(document.createTextNode(" "));
+    }
   }
 }
 function renderLink(container, ref, translation, website) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,15 @@
 {
   "name": "obsidian-bible-verse",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-bible-verse",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "license": "GPL-3.0",
       "devDependencies": {
         "@types/node": "^16.11.6",
-        "builtin-modules": "^3.3.0",
         "esbuild": "0.17.3",
         "obsidian": "latest",
         "tslib": "2.4.0",
@@ -456,19 +455,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "*"
-      }
-    },
-    "node_modules/builtin-modules": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
-      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/crelt": {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -160,7 +160,7 @@ async function renderText(el: HTMLElement, text: string, app: App, component: Co
   // We move the children out of the <p> and then remove it, avoiding innerHTML.
   if (isInline) {
     // Flatten all <p> wrappers — inline context can't hold block elements.
-    // Insert <br><br> between paragraphs to preserve the blank-line gap.
+    // Insert a para-break span between paragraph groups to preserve the gap.
     const paragraphs = Array.from(container.querySelectorAll("p"));
     for (let i = 0; i < paragraphs.length; i++) {
       const p = paragraphs[i];
@@ -173,6 +173,18 @@ async function renderText(el: HTMLElement, text: string, app: App, component: Co
         container.insertBefore(sep, p);
       }
       p.remove();
+    }
+
+    // Replace <br> elements with spaces — inline display must not have line
+    // breaks between verses. Also strip the \n text nodes that MarkdownRenderer
+    // emits after each <br>; under CM6's white-space: pre-wrap they render as
+    // an extra blank line.
+    for (const br of Array.from(container.querySelectorAll("br"))) {
+      const next = br.nextSibling;
+      if (next?.nodeType === Node.TEXT_NODE && (next as Text).data.startsWith("\n")) {
+        (next as Text).data = (next as Text).data.slice(1);
+      }
+      br.replaceWith(document.createTextNode(" "));
     }
   }
 }

--- a/styles.css
+++ b/styles.css
@@ -263,16 +263,21 @@
   }
 }
 
+/* Prevent CM6 editor's white-space: pre-wrap from being inherited into verse
+   content. Without this, the \n text nodes that MarkdownRenderer emits after
+   each <br> render as extra blank lines in Live Preview. */
+.bible-verse .bible-verse-body {
+  white-space: normal;
+}
+
 /* Paragraph spacing within verse content.
-   Scoped to known Obsidian parent contexts for enough specificity to override
-   default p margins without !important.
+   Uses our own class hierarchy for specificity — avoids relying on
+   Obsidian parent contexts which differ between reading/preview/editor.
    nl-mode verses stay compact; para-mode gets a visible paragraph gap. */
-.markdown-reading-view .bible-verse p,
-.cm-editor .bible-verse p {
+.bible-verse .bible-verse-body p {
   margin: 0;
 }
-.markdown-reading-view .bible-verse--para p + p,
-.cm-editor .bible-verse--para p + p {
+.bible-verse--para .bible-verse-body p + p {
   margin-top: 0.75em;
 }
 


### PR DESCRIPTION
## Summary

- **Block styles (callout, sidebar, blockquote) in Live Preview**: CM6's `.cm-content` inherits `white-space: pre-wrap` into rendered verse content, causing the `\n` text nodes that `MarkdownRenderer` emits after each `<br>` to render as real line breaks — doubling the gap between verses. Fixed by setting `white-space: normal` on `.bible-verse .bible-verse-body`.
- **Inline style (all modes)**: `<br>` elements were left in place after `<p>` unwrapping in `renderText`, creating line breaks inside what should be continuous quoted text. Fixed by replacing `<br>` with a space and trimming the trailing `\n` text node in the inline rendering path.

## Root cause investigation

The fix required eliminating several false hypotheses via DevTools:
- `p + p` margins were never the cause — all verses render in a single `<p>` with `<br>` breaks
- `p { margin }` and `line-height` were identical in both reading and edit mode
- The actual cause (`white-space: pre-wrap` inheritance from `.cm-content`) was identified by comparing raw `innerHTML` between modes and noticing `<br>\n` text nodes

Closes #21

## Test plan

- [x] `{1 John 3:1-3, nl, callout}` — compact in both reading mode and Live Preview
- [x] `{1 John 3:1-3, nl, sidebar}` — compact in both modes
- [x] `{1 John 3:1-3, nl, blockquote}` — compact in both modes
- [x] `{1 John 3:1-3, para, callout}` — paragraph gaps still present (regression check)
- [x] `{1 John 3:1-3, inline}` — continuous quoted text, no line breaks, both modes
- [x] Baked code block — unaffected (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
