### PR TITLE
feat: add GitHub issue forms (bug report + feature request)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,71 @@
+name: Bug report
+description: Something in the Bible Verse plugin isn't working as expected.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. If you opened this from the plugin's **Send feedback**
+        button, the version fields below are already filled in for you.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug — and what you expected to happen instead.
+      placeholder: When I render {John 3:16} inside a callout, the verse number overlaps the text...
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Create a note containing `{John 3:16}`
+        2. Switch to a callout display style
+        3. See the rendering issue
+    validations:
+      required: true
+  - type: input
+    id: plugin-version
+    attributes:
+      label: Plugin version
+      placeholder: e.g. 1.6.2
+    validations:
+      required: true
+  - type: input
+    id: obsidian-version
+    attributes:
+      label: Obsidian version
+      placeholder: e.g. 1.5.8
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Windows
+        - Linux
+        - iOS (mobile)
+        - Android (mobile)
+    validations:
+      required: true
+  - type: textarea
+    id: console
+    attributes:
+      label: Console errors (optional)
+      description: Open the developer console with Ctrl/Cmd+Shift+I and paste any red errors here.
+      render: shell
+    validations:
+      required: false
+  - type: checkboxes
+    id: prechecks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and didn't find a duplicate.
+          required: true
+        - label: I'm on the latest version of the plugin.
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & ideas (Discussions)
+    url: https://github.com/kilrkrow/obsidian-bible-verse/discussions
+    about: For open-ended questions, brainstorming, and feature spit-balling.
+  - name: Obsidian community help
+    url: https://obsidian.md/community
+    about: General Obsidian usage questions unrelated to this plugin.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,31 @@
+name: Feature request / idea
+description: Suggest an improvement or a new capability.
+title: "[Idea]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an open-ended idea rather than a concrete request? Consider starting a
+        **[Discussion](https://github.com/kilrkrow/obsidian-bible-verse/discussions)**
+        instead — it's better for back-and-forth brainstorming.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+      description: What are you trying to do that's hard or impossible today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like to see happen?
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you've considered
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

Adds a low-friction, self-deduping feedback funnel via GitHub issue forms — no hosted infra, no telemetry.

- `.github/ISSUE_TEMPLATE/bug.yml` — structured bug report. Required version/OS fields are auto-prefillable by the in-plugin "Send feedback" button (PR #2).
- `.github/ISSUE_TEMPLATE/feature.yml` — feature/idea request; nudges open-ended ideas toward Discussions.
- `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues; links to Discussions + the Obsidian community.

No source changes in this PR — templates only.

## Notes

- The `os` dropdown prefills unreliably across GitHub web/mobile and degrades gracefully to manual selection (acceptable).
- The field `id`s in `bug.yml` (`plugin-version`, `obsidian-version`, `os`) are the prefill keys the PR #2 button targets.

## Test plan

- [ ] Open **Issues → New issue** and confirm the Bug report and Feature request forms render, and that blank issues are disabled.
- [ ] Confirm the Discussions / Obsidian community links appear in the chooser.

---
Initiative: `inits/2026-06-12-bible-verse-feedback` (kilrkrow/initiatives). Part 1 of 2. **Please do not merge — for human review.**