### PR TITLE
feat: in-plugin "Send feedback" button + report-bug command

### DIFF
--- a/src/feedback.ts
+++ b/src/feedback.ts
@@ -1,0 +1,53 @@
+// ---------------------------------------------------------------------------
+// In-plugin "Send feedback" — opens a GitHub issue form with the user's
+// version info pre-filled. No telemetry: nothing is sent until the user
+// clicks, and the browser opens the form for them to review and submit.
+// ---------------------------------------------------------------------------
+import { apiVersion, Platform, Setting } from "obsidian";
+
+const REPO = "kilrkrow/obsidian-bible-verse";
+
+function osLabel(): string {
+  if (Platform.isMacOS) return "macOS";
+  if (Platform.isWin) return "Windows";
+  if (Platform.isLinux) return "Linux";
+  if (Platform.isIosApp) return "iOS (mobile)";
+  if (Platform.isAndroidApp) return "Android (mobile)";
+  return "Unknown";
+}
+
+/** Build a prefilled bug-report URL. Field keys must match the `id`s in bug.yml. */
+export function bugReportUrl(pluginVersion: string): string {
+  const params = new URLSearchParams({
+    template: "bug.yml",
+    "plugin-version": pluginVersion,
+    "obsidian-version": apiVersion, // running Obsidian version, exported by the API
+    os: osLabel(),
+  });
+  return `https://github.com/${REPO}/issues/new?${params.toString()}`;
+}
+
+/** Build the feature/idea issue URL. */
+export function ideaUrl(): string {
+  return `https://github.com/${REPO}/issues/new?template=feature.yml`;
+}
+
+// Settings tab: call this inside BibleVerseSettingTab.display().
+// `this.plugin.manifest.version` gives the installed plugin version.
+export function addFeedbackSetting(containerEl: HTMLElement, pluginVersion: string): void {
+  new Setting(containerEl)
+    .setName("Send feedback")
+    .setDesc("Report a bug (version info pre-filled) or suggest an idea on GitHub.")
+    .addButton((btn) =>
+      btn
+        .setButtonText("Report a bug")
+        .setCta()
+        .onClick(() => window.open(bugReportUrl(pluginVersion))),
+    )
+    .addExtraButton((btn) =>
+      btn
+        .setIcon("lightbulb")
+        .setTooltip("Suggest an idea")
+        .onClick(() => window.open(ideaUrl())),
+    );
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,7 @@ import { BibleReferenceSuggest } from "./suggest";
 import { buildViewPlugin } from "./view-plugin";
 import { HELLOAO_ABBREV, HELLOAO_TRANSLATIONS } from "./constants";
 import { verseFetchedEffect } from "./effects";
+import { bugReportUrl } from "./feedback";
 
 export default class BibleVersePlugin extends Plugin {
   settings: BibleVerseSettings = DEFAULT_SETTINGS;
@@ -199,6 +200,12 @@ export default class BibleVersePlugin extends Plugin {
         }
         new Notice("No Bible reference found at cursor.");
       },
+    });
+
+    this.addCommand({
+      id: "report-bug",
+      name: "Report a bug on GitHub",
+      callback: () => window.open(bugReportUrl(this.manifest.version)),
     });
   }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -2,6 +2,7 @@ import { App, PluginSettingTab, Setting } from "obsidian";
 import type BibleVersePlugin from "./main";
 import { BibleWebsite, DisplayStyle } from "./types";
 import { HELLOAO_TRANSLATIONS } from "./constants";
+import { addFeedbackSetting } from "./feedback";
 
 function df(text: string, ...examples: string[]): DocumentFragment {
   const frag = document.createDocumentFragment();
@@ -223,5 +224,8 @@ export class BibleVerseSettingTab extends PluginSettingTab {
       text: "Note: Some translations may require attribution if you publish your notes. Check individual license terms if sharing content publicly.",
       cls: "bible-verse-settings-note",
     });
+
+    new Setting(containerEl).setName("Feedback").setHeading();
+    addFeedbackSetting(containerEl, this.plugin.manifest.version);
   }
 }


### PR DESCRIPTION
## Summary

Adds a user-initiated way to send feedback from inside the plugin. Nothing is transmitted automatically — a click opens a GitHub issue form in the browser with the user's version info pre-filled, for them to review and submit. **No telemetry.**

- **New `src/feedback.ts`** — builds a prefilled bug-report URL from `apiVersion` (running Obsidian version) + `Platform` (OS) and `manifest.version` (plugin version). Exposes `addFeedbackSetting()` (settings UI), `bugReportUrl()` and `ideaUrl()`.
- **`src/settings.ts`** — adds a "Feedback" heading + the Send feedback setting (a "Report a bug" CTA button and a lightbulb "Suggest an idea" extra-button) at the end of `display()`.
- **`src/main.ts`** — adds a `report-bug` command ("Report a bug on GitHub") to `onload()`.

The prefilled field keys (`plugin-version`, `obsidian-version`, `os`) match the `id`s in `bug.yml` from #24, so the form lands pre-populated.

## Notes / deviations from the handoff snippet

- `bugReportUrl` is **exported** (handoff required this so the `onload()` command can import it). `ideaUrl` is exported too for symmetry.
- Dropped the unused `type App` import from the original snippet; added an explicit `void` return on `addFeedbackSetting`.
- Helper lives at `src/feedback.ts` to match the repo's `src/` layout.

## Verification

- The npm registry isn't reachable in my build sandbox, so I couldn't run the full `npm run build`. Instead I pulled the real `obsidian@latest` type declarations + TypeScript 4.7.4 (the repo's pinned version) from the CDN and ran `tsc --noEmit` with the repo's compiler options (`target ES6`, `noImplicitAny`, `strictNullChecks`, `skipLibCheck`):
  - `src/feedback.ts` — compiles clean.
  - A harness reproducing the exact two call sites (`PluginSettingTab.display()` → `addFeedbackSetting(containerEl, this.plugin.manifest.version)`; `Plugin.addCommand` → `window.open(bugReportUrl(this.manifest.version))`) — compiles clean.
- Changes are additive and isolated; no existing modules' types are altered.

## Test plan

- [ ] `npm run build` (full toolchain) is green.
- [ ] Settings → Bible Verse → **Feedback**: "Report a bug" opens the bug form with plugin/Obsidian version (and OS where supported) pre-filled.
- [ ] The lightbulb button opens the feature/idea form.
- [ ] Command palette → "Bible Verse: Report a bug on GitHub" opens the same prefilled bug form.

---
Initiative: `inits/2026-06-12-bible-verse-feedback` (kilrkrow/initiatives). Part 2 of 2; pairs with #24. **Please do not merge — for human review.**