### PR TITLE
feat: bake to a native collapsible callout (+ bake token)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Look up and display Bible verses directly in your Obsidian notes. Powered by the
 - **IntelliSense autocomplete** — Typing inside `{…}` shows book name suggestions and confirms complete references
 - **Code block display** — Use ` ```bible ` blocks for full verse rendering with custom translation
 - **Comparison view** — Compare verses across multiple translations side by side
-- **Multiple display styles** — Sidebar, Callout, Blockquote, or Inline
+- **Multiple display styles** — Sidebar, Callout, Blockquote, Inline, or Native callout (baked, collapsible)
 - **Bible website links** — Links to BibleHub, BibleGateway, Blue Letter Bible, or Bible.com
 - **Local caching** — Fetched verses are cached locally to reduce API calls
 - **Markdown Support** — Bold, italics, and highlights are preserved within "baked" scripture text
@@ -64,7 +64,7 @@ Selecting a book-only suggestion inserts it with a trailing space so you can con
 
 ### Inline Translation and Style Overrides
 
-Both a translation and a display style can be specified inside the braces by appending comma-separated tokens after the reference. Translation codes are matched first, then a known style keyword (`sidebar`, `callout`, `blockquote`, `inline`) wins when ambiguous.
+Both a translation and a display style can be specified inside the braces by appending comma-separated tokens after the reference. Translation codes are matched first, then a known style keyword (`sidebar`, `callout`, `blockquote`, `inline`, `native-callout`) wins when ambiguous.
 
 ```
 {John 3:16, KJV}                  -- override translation
@@ -86,6 +86,21 @@ You can override your global settings for verse numbers and line breaks on a per
 {John 3:16-17, KJV, nl}          -- KJV with each verse on a new line
 {John 3:16-17, KJV, nl, no-v}    -- KJV, new lines, no numbers
 ```
+
+### Baking into your note (`bake` and `native-callout`)
+
+"Baking" writes a verse's **text permanently into your note** as ordinary Markdown, so it reads even without the plugin. Two tokens trigger a one-way bake on render — after which the plugin no longer tracks that reference (it's just text you own):
+
+*   `bake` — bakes into a ` ```bible ` code block (the same format as the bake commands).
+*   `native-callout` (alias `nco`) — bakes into a real, **collapsible** Obsidian callout: `> [!quote]+ [John 3:16 (KJV)](…)`. Because it's a genuine callout, it inherits your theme, icon packs, and fold behavior. Add `-` to start it collapsed (`nco-`), `+` to force expanded.
+
+```
+{John 3:16, bake}                -- bake into a code block
+{John 3:16, native-callout}      -- bake into a collapsible callout (expanded)
+{John 3:16, ESV, nco-}           -- ESV, baked as a callout that starts collapsed
+```
+
+The callout type (default `quote`) is configurable in **Settings → Bible Verse → Native callout type** — set it to `bible` (or whatever your icon pack defines) to apply custom icons. Selecting **Native callout** as your *default* display style will auto-bake every reference you add. In the editor, a reference that will bake shows a placeholder pill until the note is viewed in Reading mode.
 
 ### ESV (with your own API key)
 

--- a/main.js
+++ b/main.js
@@ -27,7 +27,7 @@ __export(main_exports, {
   default: () => BibleVersePlugin
 });
 module.exports = __toCommonJS(main_exports);
-var import_obsidian9 = require("obsidian");
+var import_obsidian10 = require("obsidian");
 
 // src/types.ts
 var DEFAULT_SETTINGS = {
@@ -42,7 +42,8 @@ var DEFAULT_SETTINGS = {
   bakeInline: false,
   paragraphBreaks: false,
   helperMode: true,
-  esvApiKey: ""
+  esvApiKey: "",
+  nativeCalloutType: "quote"
 };
 
 // src/constants.ts
@@ -638,7 +639,8 @@ var KNOWN_STYLES = [
   "sidebar",
   "callout",
   "blockquote",
-  "inline"
+  "inline",
+  "native-callout"
 ];
 function isKnownStyle(token) {
   return KNOWN_STYLES.includes(token.toLowerCase());
@@ -653,7 +655,9 @@ function parseInlineSpec(content) {
       styleOverride: null,
       verseNewLine: null,
       showVerseNumbers: null,
-      paragraphBreaks: null
+      paragraphBreaks: null,
+      bake: false,
+      calloutCollapsed: false
     };
   }
   const parts = trimmed.split(",").map((p) => p.trim());
@@ -664,10 +668,26 @@ function parseInlineSpec(content) {
   let verseNewLine = null;
   let showVerseNumbers = null;
   let paragraphBreaks = null;
+  let bake = false;
+  let calloutCollapsed = false;
   let cut = parts.length;
   while (cut > 1) {
     const tok = parts[cut - 1];
     const low = tok.toLowerCase();
+    if (low === "bake") {
+      bake = true;
+      cut--;
+      continue;
+    }
+    const ncMatch = low.match(/^(?:native-callout|nco)([+-])?$/);
+    if (ncMatch) {
+      if (styleOverride !== null)
+        break;
+      styleOverride = "native-callout";
+      calloutCollapsed = ncMatch[1] === "-";
+      cut--;
+      continue;
+    }
     if (low === "nl") {
       if (verseNewLine === null)
         verseNewLine = true;
@@ -726,7 +746,7 @@ function parseInlineSpec(content) {
   const ref = parseReference(refStr);
   if (!ref)
     return null;
-  return { ref, translations, styleOverride, verseNewLine, showVerseNumbers, paragraphBreaks };
+  return { ref, translations, styleOverride, verseNewLine, showVerseNumbers, paragraphBreaks, bake, calloutCollapsed };
 }
 function formatReference(ref) {
   let s = `${ref.book} ${ref.chapter}`;
@@ -988,6 +1008,17 @@ var VerseCache = class {
 var INLINE_REF_REGEX = /\{([A-Za-z0-9][^}\n]*)\}/g;
 var CODEBLOCK_REGEX = /```bible\s*\n([\s\S]*?)\n```/g;
 var CODEBLOCK_BAKE_SEPARATOR = "\n---\n";
+function formatCalloutBake(verse, calloutType, collapsed, url) {
+  const fold = collapsed ? "-" : "+";
+  const title = `[${verse.reference} (${verse.translation})](${url})`;
+  const lines = verse.text.split("\n").map((l) => l.length > 0 ? `> ${l}` : ">");
+  if (verse.requireAttribution && verse.copyright) {
+    lines.push(">");
+    lines.push(`> ${verse.copyright}`);
+  }
+  return `> [!${calloutType}]${fold} ${title}
+${lines.join("\n")}`;
+}
 var Baker = class {
   constructor(app) {
     this.app = app;
@@ -1052,14 +1083,15 @@ var Baker = class {
    * Bake a verse into the content.
    * If it's an inline reference, it is CONVERTED to a code block.
    */
-  bakeVerse(content, refRaw, verse, type = "inline") {
+  bakeVerse(content, refRaw, verse, type = "inline", opts) {
+    var _a, _b, _c;
     if (type === "inline") {
-      const block = `\`\`\`bible
+      const block = (opts == null ? void 0 : opts.format) === "callout" ? formatCalloutBake(verse, (_a = opts.calloutType) != null ? _a : "quote", (_b = opts.collapsed) != null ? _b : false, (_c = opts.url) != null ? _c : "") : `\`\`\`bible
 ${verse.reference}
 translation: ${verse.translation}
 ${CODEBLOCK_BAKE_SEPARATOR}${verse.text}
 \`\`\``;
-      return content.replace(refRaw, block);
+      return content.replace(refRaw, () => block);
     } else {
       const separatorIdx = refRaw.indexOf(CODEBLOCK_BAKE_SEPARATOR);
       let newBlock;
@@ -1147,7 +1179,46 @@ ${CODEBLOCK_BAKE_SEPARATOR}${verse.text}
 };
 
 // src/settings.ts
+var import_obsidian4 = require("obsidian");
+
+// src/feedback.ts
 var import_obsidian3 = require("obsidian");
+var REPO = "kilrkrow/obsidian-bible-verse";
+function osLabel() {
+  if (import_obsidian3.Platform.isMacOS)
+    return "macOS";
+  if (import_obsidian3.Platform.isWin)
+    return "Windows";
+  if (import_obsidian3.Platform.isLinux)
+    return "Linux";
+  if (import_obsidian3.Platform.isIosApp)
+    return "iOS (mobile)";
+  if (import_obsidian3.Platform.isAndroidApp)
+    return "Android (mobile)";
+  return "Unknown";
+}
+function bugReportUrl(pluginVersion) {
+  const params = new URLSearchParams({
+    template: "bug.yml",
+    "plugin-version": pluginVersion,
+    "obsidian-version": import_obsidian3.apiVersion,
+    // running Obsidian version, exported by the API
+    os: osLabel()
+  });
+  return `https://github.com/${REPO}/issues/new?${params.toString()}`;
+}
+function ideaUrl() {
+  return `https://github.com/${REPO}/issues/new?template=feature.yml`;
+}
+function addFeedbackSetting(containerEl, pluginVersion) {
+  new import_obsidian3.Setting(containerEl).setName("Send feedback").setDesc("Report a bug (version info pre-filled) or suggest an idea on GitHub.").addButton(
+    (btn) => btn.setButtonText("Report a bug").setCta().onClick(() => window.open(bugReportUrl(pluginVersion)))
+  ).addExtraButton(
+    (btn) => btn.setIcon("lightbulb").setTooltip("Suggest an idea").onClick(() => window.open(ideaUrl()))
+  );
+}
+
+// src/settings.ts
 function df(text, ...examples) {
   const frag = document.createDocumentFragment();
   frag.appendChild(document.createTextNode(text));
@@ -1159,7 +1230,7 @@ function df(text, ...examples) {
   }
   return frag;
 }
-var BibleVerseSettingTab = class extends import_obsidian3.PluginSettingTab {
+var BibleVerseSettingTab = class extends import_obsidian4.PluginSettingTab {
   constructor(app, plugin) {
     super(app, plugin);
     this.plugin = plugin;
@@ -1167,7 +1238,7 @@ var BibleVerseSettingTab = class extends import_obsidian3.PluginSettingTab {
   display() {
     const { containerEl } = this;
     containerEl.empty();
-    new import_obsidian3.Setting(containerEl).setName("Default translation").setDesc(df("The Bible translation to use by default. Override per-reference:", "{Romans 8:28, KJV}")).addDropdown((dropdown) => {
+    new import_obsidian4.Setting(containerEl).setName("Default translation").setDesc(df("The Bible translation to use by default. Override per-reference:", "{Romans 8:28, KJV}")).addDropdown((dropdown) => {
       for (const t of HELLOAO_TRANSLATIONS) {
         dropdown.addOption(t.id, t.name);
       }
@@ -1176,27 +1247,37 @@ var BibleVerseSettingTab = class extends import_obsidian3.PluginSettingTab {
         await this.plugin.saveSettings();
       });
     });
-    new import_obsidian3.Setting(containerEl).setName("Preferred Bible website").setDesc("Which website to link verse references to").addDropdown(
+    new import_obsidian4.Setting(containerEl).setName("Preferred Bible website").setDesc("Which website to link verse references to").addDropdown(
       (dropdown) => dropdown.addOption("BibleHub", "BibleHub").addOption("BibleGateway", "BibleGateway").addOption("BlueLetter", "Blue Letter Bible").addOption("BibleCom", "Bible.com").setValue(this.plugin.settings.preferredWebsite).onChange(async (value) => {
         this.plugin.settings.preferredWebsite = value;
         await this.plugin.saveSettings();
         this.plugin.refreshLivePreview();
       })
     );
-    new import_obsidian3.Setting(containerEl).setName("Display style").setDesc(df("How verses are visually presented. Override per-reference:", "{Romans 8:28, callout}", "{Romans 8:28, sidebar}", "{Romans 8:28, inline}")).addDropdown(
-      (dropdown) => dropdown.addOption("sidebar", "Sidebar").addOption("callout", "Callout").addOption("blockquote", "Blockquote").addOption("inline", "Inline").setValue(this.plugin.settings.displayStyle).onChange(async (value) => {
+    new import_obsidian4.Setting(containerEl).setName("Display style").setDesc(df("How verses are visually presented. Override per-reference:", "{Romans 8:28, callout}", "{Romans 8:28, sidebar}", "{Romans 8:28, inline}")).addDropdown(
+      (dropdown) => dropdown.addOption("sidebar", "Sidebar").addOption("callout", "Callout").addOption("blockquote", "Blockquote").addOption("inline", "Inline").addOption("native-callout", "Native callout (bakes into note)").setValue(this.plugin.settings.displayStyle).onChange(async (value) => {
         this.plugin.settings.displayStyle = value;
         await this.plugin.saveSettings();
       })
     );
-    new import_obsidian3.Setting(containerEl).setName("Sidebar top padding").setDesc("Adjust the top spacing for the Sidebar style (in ems)").addSlider(
+    containerEl.createEl("p", {
+      cls: "bible-verse-settings-note",
+      text: "\u201CBake\u201D means writing a verse\u2019s text permanently into your note as ordinary Markdown, so it reads without the plugin. The {\u2026, bake} token bakes to a code block; the \u201CNative callout\u201D style (or {\u2026, native-callout} / {\u2026, nco}) bakes to a real, collapsible Obsidian callout. Baking is one-way \u2014 the plugin stops tracking it afterward. Note: choosing \u201CNative callout\u201D as your default here will auto-bake every scripture reference you add."
+    });
+    new import_obsidian4.Setting(containerEl).setName("Native callout type").setDesc(df("Callout type used when baking as a native callout \u2014 match a type your theme or icon pack styles.", "quote", "bible")).addText(
+      (text) => text.setPlaceholder("quote").setValue(this.plugin.settings.nativeCalloutType).onChange(async (value) => {
+        this.plugin.settings.nativeCalloutType = value.trim() || "quote";
+        await this.plugin.saveSettings();
+      })
+    );
+    new import_obsidian4.Setting(containerEl).setName("Sidebar top padding").setDesc("Adjust the top spacing for the Sidebar style (in ems)").addSlider(
       (slider) => slider.setLimits(0, 2, 0.1).setValue(this.plugin.settings.sidebarTopPadding).setDynamicTooltip().onChange(async (value) => {
         this.plugin.settings.sidebarTopPadding = value;
         await this.plugin.saveSettings();
         this.plugin.updateStyles();
       })
     );
-    new import_obsidian3.Setting(containerEl).setName("Persist verse text in notes").setDesc(
+    new import_obsidian4.Setting(containerEl).setName("Persist verse text in notes").setDesc(
       "When enabled, fetched verse text is automatically written into note source (bake mode)"
     ).addToggle(
       (toggle) => toggle.setValue(this.plugin.settings.persistVerseText).onChange(async (value) => {
@@ -1204,44 +1285,44 @@ var BibleVerseSettingTab = class extends import_obsidian3.PluginSettingTab {
         await this.plugin.saveSettings();
       })
     );
-    new import_obsidian3.Setting(containerEl).setName("Show verse numbers").setDesc(df("Display verse numbers in the rendered text. Override per-reference:", "{Romans 8:28-30, v}", "{Romans 8:28-30, no-v}")).addToggle(
+    new import_obsidian4.Setting(containerEl).setName("Show verse numbers").setDesc(df("Display verse numbers in the rendered text. Override per-reference:", "{Romans 8:28-30, v}", "{Romans 8:28-30, no-v}")).addToggle(
       (toggle) => toggle.setValue(this.plugin.settings.showVerseNumbers).onChange(async (value) => {
         this.plugin.settings.showVerseNumbers = value;
         await this.plugin.saveSettings();
         this.display();
       })
     );
-    new import_obsidian3.Setting(containerEl).setName("Show attribution").setDesc("Display license and copyright links below verses.").addToggle(
+    new import_obsidian4.Setting(containerEl).setName("Show attribution").setDesc("Display license and copyright links below verses.").addToggle(
       (toggle) => toggle.setValue(this.plugin.settings.showAttribution).onChange(async (value) => {
         this.plugin.settings.showAttribution = value;
         await this.plugin.saveSettings();
       })
     );
-    new import_obsidian3.Setting(containerEl).setName("New line per verse").setDesc(df("Start each verse on a new line. Override per-reference:", "{Romans 8:28-30, nl}", "{Romans 8:28-30, no-nl}")).addToggle(
+    new import_obsidian4.Setting(containerEl).setName("New line per verse").setDesc(df("Start each verse on a new line. Override per-reference:", "{Romans 8:28-30, nl}", "{Romans 8:28-30, no-nl}")).addToggle(
       (toggle) => toggle.setValue(this.plugin.settings.verseNewLine).setDisabled(!this.plugin.settings.showVerseNumbers).onChange(async (value) => {
         this.plugin.settings.verseNewLine = value;
         await this.plugin.saveSettings();
       })
     );
-    new import_obsidian3.Setting(containerEl).setName("Bake inline references").setDesc("If enabled, baking a note will convert {ref} into a bible code block. If disabled, only code blocks are baked.").addToggle(
+    new import_obsidian4.Setting(containerEl).setName("Bake inline references").setDesc("If enabled, baking a note will convert {ref} into a bible code block. If disabled, only code blocks are baked.").addToggle(
       (toggle) => toggle.setValue(this.plugin.settings.bakeInline).onChange(async (value) => {
         this.plugin.settings.bakeInline = value;
         await this.plugin.saveSettings();
       })
     );
-    new import_obsidian3.Setting(containerEl).setName("Reading sections").setDesc(df("Group verses by natural paragraph breaks. Override per-reference:", "{Luke 19, para}", "{Luke 19, no-para}")).addToggle(
+    new import_obsidian4.Setting(containerEl).setName("Reading sections").setDesc(df("Group verses by natural paragraph breaks. Override per-reference:", "{Luke 19, para}", "{Luke 19, no-para}")).addToggle(
       (toggle) => toggle.setValue(this.plugin.settings.paragraphBreaks).onChange(async (value) => {
         this.plugin.settings.paragraphBreaks = value;
         await this.plugin.saveSettings();
       })
     );
-    new import_obsidian3.Setting(containerEl).setName("IntelliSense helper mode").setDesc("When a reference is complete, show a menu of all available modifiers (style, formatting, reading sections).").addToggle(
+    new import_obsidian4.Setting(containerEl).setName("IntelliSense helper mode").setDesc("When a reference is complete, show a menu of all available modifiers (style, formatting, reading sections).").addToggle(
       (toggle) => toggle.setValue(this.plugin.settings.helperMode).onChange(async (value) => {
         this.plugin.settings.helperMode = value;
         await this.plugin.saveSettings();
       })
     );
-    new import_obsidian3.Setting(containerEl).setName("Syntax reference").setHeading();
+    new import_obsidian4.Setting(containerEl).setName("Syntax reference").setHeading();
     const details = containerEl.createEl("details", { cls: "bible-verse-settings-ref" });
     details.createEl("summary", { text: "Show token syntax" });
     const refTable = details.createEl("table");
@@ -1263,12 +1344,12 @@ var BibleVerseSettingTab = class extends import_obsidian3.PluginSettingTab {
       tr.createEl("td").createEl("code", { text: token });
       tr.createEl("td", { text: desc });
     }
-    new import_obsidian3.Setting(containerEl).setName("Commercial translations").setHeading();
+    new import_obsidian4.Setting(containerEl).setName("Commercial translations").setHeading();
     const apiDesc = containerEl.createDiv({ cls: "bible-verse-settings-info" });
     apiDesc.createEl("p", {
       text: "Enter an ESV API key to unlock inline ESV text. ESV attribution is always shown, as required by Crossway's license. Other commercial translations (NIV, NKJV, NLT, AMP, CSB, NASB) render as links only."
     });
-    new import_obsidian3.Setting(containerEl).setName("ESV API key").setDesc(
+    new import_obsidian4.Setting(containerEl).setName("ESV API key").setDesc(
       df("Unlocks English Standard Version inline text.", "Get a free key at api.esv.org")
     ).addText(
       (text) => text.setPlaceholder("Enter your ESV API key").setValue(this.plugin.settings.esvApiKey).onChange(async (value) => {
@@ -1281,7 +1362,7 @@ var BibleVerseSettingTab = class extends import_obsidian3.PluginSettingTab {
       if (input)
         input.type = "password";
     });
-    new import_obsidian3.Setting(containerEl).setName("Data source and licensing").setHeading();
+    new import_obsidian4.Setting(containerEl).setName("Data source and licensing").setHeading();
     const info = containerEl.createDiv({ cls: "bible-verse-settings-info" });
     info.createEl("p", {
       text: "Free translations are provided by the HelloAO Bible API. ESV text is fetched from the ESV API using your own key."
@@ -1299,11 +1380,13 @@ var BibleVerseSettingTab = class extends import_obsidian3.PluginSettingTab {
       text: "Note: Some translations may require attribution if you publish your notes. Check individual license terms if sharing content publicly.",
       cls: "bible-verse-settings-note"
     });
+    new import_obsidian4.Setting(containerEl).setName("Feedback").setHeading();
+    addFeedbackSetting(containerEl, this.plugin.manifest.version);
   }
 };
 
 // src/renderer.ts
-var import_obsidian4 = require("obsidian");
+var import_obsidian5 = require("obsidian");
 
 // src/linker.ts
 function generateLink(ref, translation, website) {
@@ -1441,7 +1524,7 @@ async function renderSidebar(el, ref, verse, url, showAttribution, app, componen
 async function renderCallout(el, ref, verse, url, showAttribution, app, component) {
   const header = el.createDiv({ cls: "bible-verse-header" });
   const iconSpan = header.createSpan({ cls: "bible-verse-icon" });
-  (0, import_obsidian4.setIcon)(iconSpan, "book-open");
+  (0, import_obsidian5.setIcon)(iconSpan, "book-open");
   const link = header.createEl("a", {
     cls: "bible-verse-ref",
     text: `${ref} (${verse.translation})`,
@@ -1490,7 +1573,7 @@ async function renderInline(el, ref, verse, url, showAttribution, app, component
 async function renderText(el, text, app, component, isInline = false, verseNewLine = false) {
   const container = isInline ? el.createSpan() : el.createDiv();
   const escaped = text.replace(/^(\d+)([.)])\s/gm, "$1\\$2 ");
-  await import_obsidian4.MarkdownRenderer.render(app, escaped, container, "", component);
+  await import_obsidian5.MarkdownRenderer.render(app, escaped, container, "", component);
   if (isInline) {
     flattenInlineContent(container, verseNewLine);
   }
@@ -1500,7 +1583,7 @@ function renderLink(container, ref, translation, website) {
   const url = generateLink(ref, translation, website);
   const span = container.createSpan({ cls: "bible-verse bible-verse-link" });
   const iconSpan = span.createSpan({ cls: "bible-verse-icon" });
-  (0, import_obsidian4.setIcon)(iconSpan, "book-open");
+  (0, import_obsidian5.setIcon)(iconSpan, "book-open");
   const link = span.createEl("a", {
     cls: "bible-verse-ref",
     text: ` ${refStr}`,
@@ -1508,6 +1591,13 @@ function renderLink(container, ref, translation, website) {
   });
   link.setAttr("target", "_blank");
   link.setAttr("rel", "noopener");
+}
+function renderBakePending(container, ref) {
+  const refStr = formatReference(ref);
+  const pill = container.createSpan({ cls: "bible-verse-pill bible-verse-bake-pending" });
+  const iconSpan = pill.createSpan({ cls: "bible-verse-icon" });
+  (0, import_obsidian5.setIcon)(iconSpan, "save");
+  pill.createSpan({ text: `${refStr} \u2014 will bake` });
 }
 async function renderComparison(container, ref, verses, website, showAttribution, app, component) {
   const wrapper = container.createDiv({ cls: "bible-verse-comparison" });
@@ -1542,8 +1632,8 @@ function renderError(container, message) {
 }
 
 // src/quick-insert-modal.ts
-var import_obsidian5 = require("obsidian");
-var QuickInsertModal = class extends import_obsidian5.Modal {
+var import_obsidian6 = require("obsidian");
+var QuickInsertModal = class extends import_obsidian6.Modal {
   constructor(app, onSubmit) {
     super(app);
     this.onSubmit = onSubmit;
@@ -1590,7 +1680,7 @@ var QuickInsertModal = class extends import_obsidian5.Modal {
         }
       }
     });
-    new import_obsidian5.Setting(contentEl).setName("Also open on Bible site").addToggle((toggle) => toggle.onChange((val) => {
+    new import_obsidian6.Setting(contentEl).setName("Also open on Bible site").addToggle((toggle) => toggle.onChange((val) => {
       openInBrowser = val;
     }));
   }
@@ -1600,8 +1690,8 @@ var QuickInsertModal = class extends import_obsidian5.Modal {
 };
 
 // src/suggest.ts
-var import_obsidian6 = require("obsidian");
-var BibleReferenceSuggest = class extends import_obsidian6.EditorSuggest {
+var import_obsidian7 = require("obsidian");
+var BibleReferenceSuggest = class extends import_obsidian7.EditorSuggest {
   constructor(app, plugin) {
     super(app);
     // Canonical book list in canonical order (Genesis → Revelation)
@@ -1662,8 +1752,11 @@ var BibleReferenceSuggest = class extends import_obsidian6.EditorSuggest {
                 suggestions.push(`${prefix}, ${style}`);
               }
             }
+            if ("nco".startsWith(modPart)) {
+              suggestions.push(`${prefix}, nco`);
+            }
           }
-          const flags = ["nl", "no-nl", "v", "no-v", "para", "no-para"];
+          const flags = ["nl", "no-nl", "v", "no-v", "para", "no-para", "bake"];
           for (const flag of flags) {
             if (flag.startsWith(modPart)) {
               suggestions.push(`${prefix}, ${flag}`);
@@ -1684,6 +1777,8 @@ var BibleReferenceSuggest = class extends import_obsidian6.EditorSuggest {
             { value: `${refStr}, sidebar`, label: "Sidebar" },
             { value: `${refStr}, blockquote`, label: "Blockquote" },
             { value: `${refStr}, inline`, label: "Inline" },
+            { value: `${refStr}, native-callout`, label: "Native callout (bakes into note)" },
+            { value: `${refStr}, bake`, label: "Bake into note" },
             { value: `${refStr}, nl`, label: "New line per verse" },
             { value: `${refStr}, no-nl`, label: "Single paragraph" },
             { value: `${refStr}, no-v`, label: "Hide verse numbers" },
@@ -1736,7 +1831,7 @@ var BibleReferenceSuggest = class extends import_obsidian6.EditorSuggest {
     }
     if (item.value.includes(",")) {
       const iconEl = el.createEl("span", { cls: "bible-suggest-icon" });
-      (0, import_obsidian6.setIcon)(iconEl, "sliders-horizontal");
+      (0, import_obsidian7.setIcon)(iconEl, "sliders-horizontal");
       const parts = item.value.split(",");
       const modifier = parts[parts.length - 1].trim();
       const prefix = parts.slice(0, -1).join(",").trim();
@@ -1751,7 +1846,7 @@ var BibleReferenceSuggest = class extends import_obsidian6.EditorSuggest {
       }
     } else {
       const iconEl = el.createEl("span", { cls: "bible-suggest-icon" });
-      (0, import_obsidian6.setIcon)(iconEl, "book-open");
+      (0, import_obsidian7.setIcon)(iconEl, "book-open");
       el.createEl("span", { cls: "bible-suggest-text", text: item.value });
     }
   }
@@ -1801,7 +1896,7 @@ var BibleReferenceSuggest = class extends import_obsidian6.EditorSuggest {
 // src/view-plugin.ts
 var import_view = require("@codemirror/view");
 var import_state2 = require("@codemirror/state");
-var import_obsidian7 = require("obsidian");
+var import_obsidian8 = require("obsidian");
 
 // src/effects.ts
 var import_state = require("@codemirror/state");
@@ -1815,12 +1910,17 @@ var BibleVerseWidget = class extends import_view.WidgetType {
     this.spec = spec;
   }
   toDOM(view) {
-    var _a, _b, _c, _d, _e;
+    var _a, _b, _c, _d, _e, _f;
     const container = document.createElement("span");
     container.className = "bible-verse-livepreview";
     const vnL = (_a = this.spec.verseNewLine) != null ? _a : this.spec.plugin.settings.verseNewLine;
     const sVN = (_b = this.spec.showVerseNumbers) != null ? _b : this.spec.plugin.settings.showVerseNumbers;
     const pb = (_c = this.spec.paragraphBreaks) != null ? _c : this.spec.plugin.settings.paragraphBreaks;
+    const effectiveStyle = (_d = this.spec.styleOverride) != null ? _d : this.spec.plugin.settings.displayStyle;
+    if ((this.spec.bake || effectiveStyle === "native-callout") && this.spec.translations.length < 2) {
+      renderBakePending(container, this.spec.ref);
+      return container;
+    }
     if (this.spec.translations.length === 1 && this.spec.plugin.isTranslationLinkOnly(this.spec.translations[0])) {
       this.renderPill(container);
       return container;
@@ -1847,12 +1947,12 @@ var BibleVerseWidget = class extends import_view.WidgetType {
           container,
           this.spec.ref,
           cached,
-          (_d = this.spec.styleOverride) != null ? _d : this.spec.plugin.settings.displayStyle,
+          (_e = this.spec.styleOverride) != null ? _e : this.spec.plugin.settings.displayStyle,
           this.spec.preferredWebsite,
           this.spec.plugin.settings.showAttribution,
           this.spec.plugin.app,
           this.spec.plugin,
-          (_e = this.spec.paragraphBreaks) != null ? _e : this.spec.plugin.settings.paragraphBreaks,
+          (_f = this.spec.paragraphBreaks) != null ? _f : this.spec.plugin.settings.paragraphBreaks,
           vnL
         );
       } else {
@@ -1866,7 +1966,7 @@ var BibleVerseWidget = class extends import_view.WidgetType {
     const a = document.createElement("a");
     a.className = "bible-verse-pill";
     const iconSpan = a.createSpan({ cls: "bible-verse-icon" });
-    (0, import_obsidian7.setIcon)(iconSpan, "book-open");
+    (0, import_obsidian8.setIcon)(iconSpan, "book-open");
     a.createSpan({ text: " " + this.spec.label });
     a.href = this.spec.href;
     a.target = "_blank";
@@ -1936,7 +2036,7 @@ var BibleVerseWidget = class extends import_view.WidgetType {
     }
   }
   eq(other) {
-    return this.spec.label === other.spec.label && this.spec.cachedVerses.length === other.spec.cachedVerses.length && this.spec.cachedVerses.every((v, i) => v === other.spec.cachedVerses[i]) && this.spec.styleOverride === other.spec.styleOverride && this.spec.verseNewLine === other.spec.verseNewLine && this.spec.showVerseNumbers === other.spec.showVerseNumbers && this.spec.paragraphBreaks === other.spec.paragraphBreaks && this.spec.preferredWebsite === other.spec.preferredWebsite;
+    return this.spec.label === other.spec.label && this.spec.cachedVerses.length === other.spec.cachedVerses.length && this.spec.cachedVerses.every((v, i) => v === other.spec.cachedVerses[i]) && this.spec.styleOverride === other.spec.styleOverride && this.spec.verseNewLine === other.spec.verseNewLine && this.spec.showVerseNumbers === other.spec.showVerseNumbers && this.spec.paragraphBreaks === other.spec.paragraphBreaks && this.spec.bake === other.spec.bake && this.spec.preferredWebsite === other.spec.preferredWebsite;
   }
   ignoreEvent(event) {
     const target = event.target;
@@ -1984,7 +2084,7 @@ function buildViewPlugin(plugin) {
             const spec = parseInlineSpec(content);
             if (!spec)
               continue;
-            const { ref, translations, styleOverride, verseNewLine, showVerseNumbers, paragraphBreaks } = spec;
+            const { ref, translations, styleOverride, verseNewLine, showVerseNumbers, paragraphBreaks, bake } = spec;
             const refLabel = formatReference(ref);
             const vnL = verseNewLine != null ? verseNewLine : plugin.settings.verseNewLine;
             const sVN = showVerseNumbers != null ? showVerseNumbers : plugin.settings.showVerseNumbers;
@@ -2025,6 +2125,7 @@ function buildViewPlugin(plugin) {
               verseNewLine,
               showVerseNumbers,
               paragraphBreaks,
+              bake,
               cachedVerses,
               preferredWebsite: plugin.settings.preferredWebsite,
               plugin
@@ -2044,11 +2145,11 @@ function buildViewPlugin(plugin) {
 }
 
 // src/providers.ts
-var import_obsidian8 = require("obsidian");
+var import_obsidian9 = require("obsidian");
 async function fetchEsvPassage(ref, apiKey, settings) {
   const refStr = formatReference(ref);
   const params = buildEsvParams(refStr);
-  const response = await (0, import_obsidian8.requestUrl)({
+  const response = await (0, import_obsidian9.requestUrl)({
     url: `https://api.esv.org/v3/passage/text/?${params}`,
     headers: { Authorization: `Token ${apiKey}` }
   });
@@ -2082,7 +2183,7 @@ function getEffectiveMode(def, esvApiKey) {
 }
 
 // src/main.ts
-var BibleVersePlugin = class extends import_obsidian9.Plugin {
+var BibleVersePlugin = class extends import_obsidian10.Plugin {
   constructor() {
     super(...arguments);
     this.settings = DEFAULT_SETTINGS;
@@ -2114,9 +2215,9 @@ var BibleVersePlugin = class extends import_obsidian9.Plugin {
         );
         if (newContent !== content) {
           editor.setValue(newContent);
-          new import_obsidian9.Notice("Bible verses baked into note.");
+          new import_obsidian10.Notice("Bible verses baked into note.");
         } else {
-          new import_obsidian9.Notice("No verses to bake.");
+          new import_obsidian10.Notice("No verses to bake.");
         }
       }
     });
@@ -2132,7 +2233,7 @@ var BibleVersePlugin = class extends import_obsidian9.Plugin {
           (ref, id, abbr, nl, vn) => this.fetchVerse(ref, id, abbr, nl, vn)
         );
         editor.setValue(newContent);
-        new import_obsidian9.Notice("Bible verses refreshed.");
+        new import_obsidian10.Notice("Bible verses refreshed.");
       }
     });
     this.addCommand({
@@ -2144,7 +2245,7 @@ var BibleVersePlugin = class extends import_obsidian9.Plugin {
           this.settings.bakeInline,
           (ref, id, abbr, nl, vn) => this.fetchVerse(ref, id, abbr, nl, vn)
         );
-        new import_obsidian9.Notice(`Refreshed baked verses in ${count} files.`);
+        new import_obsidian10.Notice(`Refreshed baked verses in ${count} files.`);
       }
     });
     this.addCommand({
@@ -2156,7 +2257,7 @@ var BibleVersePlugin = class extends import_obsidian9.Plugin {
           this.settings.bakeInline,
           (ref, id, abbr, nl, vn) => this.fetchVerse(ref, id, abbr, nl, vn)
         );
-        new import_obsidian9.Notice(`Baked verses in ${count} files.`);
+        new import_obsidian10.Notice(`Baked verses in ${count} files.`);
       }
     });
     this.addCommand({
@@ -2164,7 +2265,7 @@ var BibleVersePlugin = class extends import_obsidian9.Plugin {
       name: "Strip baked text from all notes",
       callback: async () => {
         const count = await this.baker.processVault("strip", false);
-        new import_obsidian9.Notice(`Stripped baked text from ${count} files.`);
+        new import_obsidian10.Notice(`Stripped baked text from ${count} files.`);
       }
     });
     this.addCommand({
@@ -2172,7 +2273,7 @@ var BibleVersePlugin = class extends import_obsidian9.Plugin {
       name: "Clear verse cache",
       callback: async () => {
         await this.cache.clear();
-        new import_obsidian9.Notice("Bible verse cache cleared.");
+        new import_obsidian10.Notice("Bible verse cache cleared.");
       }
     });
     this.addCommand({
@@ -2204,11 +2305,11 @@ var BibleVersePlugin = class extends import_obsidian9.Plugin {
       editorCallback: (editor) => {
         const selection = editor.getSelection();
         if (!selection || selection.trim().length === 0) {
-          new import_obsidian9.Notice("No text selected.");
+          new import_obsidian10.Notice("No text selected.");
           return;
         }
         navigator.clipboard.writeText(selection.trim());
-        new import_obsidian9.Notice("Copied to clipboard. Opening search...");
+        new import_obsidian10.Notice("Copied to clipboard. Opening search...");
         const abbr = this.getTranslationAbbr();
         const url = generateSearchUrl(selection.trim(), abbr, this.settings.preferredWebsite);
         window.open(url, "_blank");
@@ -2235,8 +2336,13 @@ var BibleVersePlugin = class extends import_obsidian9.Plugin {
             }
           }
         }
-        new import_obsidian9.Notice("No Bible reference found at cursor.");
+        new import_obsidian10.Notice("No Bible reference found at cursor.");
       }
+    });
+    this.addCommand({
+      id: "report-bug",
+      name: "Report a bug on GitHub",
+      callback: () => window.open(bugReportUrl(this.manifest.version))
     });
   }
   async loadSettings() {
@@ -2321,7 +2427,7 @@ var BibleVersePlugin = class extends import_obsidian9.Plugin {
    * Inline markdown postprocessor: finds {ref} in rendered text and replaces them.
    */
   async inlinePostProcessor(el, ctx) {
-    var _a, _b, _c, _d, _e, _f;
+    var _a, _b, _c, _d, _e, _f, _g;
     const INLINE_REGEX = /\{([A-Za-z0-9][^}\n]*)\}/g;
     const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
     const nodesToProcess = [];
@@ -2348,17 +2454,29 @@ var BibleVersePlugin = class extends import_obsidian9.Plugin {
           const { ref, translations } = spec;
           const span = document.createElement("span");
           span.className = "bible-verse-container";
-          if (translations.length >= 2) {
-            this.renderInlineComparison(span, ref, translations, (_a = spec.paragraphBreaks) != null ? _a : void 0);
+          const effectiveStyle = (_a = spec.styleOverride) != null ? _a : this.settings.displayStyle;
+          const wantsBake = spec.bake || effectiveStyle === "native-callout";
+          if (wantsBake && translations.length >= 2) {
+            new import_obsidian10.Notice("Bible Verse: baking isn't supported for multi-translation comparisons.");
+            this.renderInlineComparison(span, ref, translations, (_b = spec.paragraphBreaks) != null ? _b : void 0);
+            frag.appendChild(span);
+          } else if (wantsBake) {
+            renderBakePending(span, ref);
+            frag.appendChild(span);
+            this.handleBake(ctx, match[0], spec, effectiveStyle === "native-callout" ? "callout" : "codeblock");
+          } else if (translations.length >= 2) {
+            this.renderInlineComparison(span, ref, translations, (_c = spec.paragraphBreaks) != null ? _c : void 0);
+            frag.appendChild(span);
           } else if (translations.length === 1 && this.isTranslationLinkOnly(translations[0])) {
             renderLink(span, ref, translations[0].toUpperCase(), this.settings.preferredWebsite);
+            frag.appendChild(span);
           } else {
             const translationId = translations.length === 1 ? this.resolveTranslationId(translations[0]) : this.settings.defaultTranslation;
             const abbr = translations.length === 1 ? this.getTranslationAbbr(translationId) : this.getTranslationAbbr();
-            const style = (_b = spec.styleOverride) != null ? _b : this.settings.displayStyle;
-            const vnL = (_c = spec.verseNewLine) != null ? _c : this.settings.verseNewLine;
-            const sVN = (_d = spec.showVerseNumbers) != null ? _d : this.settings.showVerseNumbers;
-            const pb = (_e = spec.paragraphBreaks) != null ? _e : this.settings.paragraphBreaks;
+            const style = effectiveStyle;
+            const vnL = (_d = spec.verseNewLine) != null ? _d : this.settings.verseNewLine;
+            const sVN = (_e = spec.showVerseNumbers) != null ? _e : this.settings.showVerseNumbers;
+            const pb = (_f = spec.paragraphBreaks) != null ? _f : this.settings.paragraphBreaks;
             const cached = this.cache.get(abbr, formatReference(ref), vnL, sVN, pb);
             if (cached) {
               await renderVerse(span, ref, cached, style, this.settings.preferredWebsite, this.settings.showAttribution, this.app, this, pb, vnL);
@@ -2366,10 +2484,10 @@ var BibleVersePlugin = class extends import_obsidian9.Plugin {
               renderLink(span, ref, abbr, this.settings.preferredWebsite);
               this.fetchAndRenderWithTranslation(span, ref, translationId, abbr, style, vnL, sVN, pb);
             }
-          }
-          frag.appendChild(span);
-          if (this.settings.persistVerseText && translations.length === 0) {
-            this.handleBake(ctx, match[0], spec);
+            frag.appendChild(span);
+            if (this.settings.persistVerseText && translations.length === 0) {
+              this.handleBake(ctx, match[0], spec);
+            }
           }
         } else {
           frag.appendChild(document.createTextNode(match[0]));
@@ -2379,7 +2497,7 @@ var BibleVersePlugin = class extends import_obsidian9.Plugin {
       if (lastIndex < text.length) {
         frag.appendChild(document.createTextNode(text.slice(lastIndex)));
       }
-      (_f = node2.parentNode) == null ? void 0 : _f.replaceChild(frag, node2);
+      (_g = node2.parentNode) == null ? void 0 : _g.replaceChild(frag, node2);
     }
   }
   async fetchAndRenderWithTranslation(container, ref, translationId, translationAbbr, style, verseNewLineOverride, showVerseNumbersOverride, paragraphBreaksOverride) {
@@ -2432,12 +2550,13 @@ var BibleVersePlugin = class extends import_obsidian9.Plugin {
       renderError(container, `Could not fetch translations for ${formatReference(ref)}.`);
     }
   }
-  async handleBake(ctx, refMarker, spec) {
+  async handleBake(ctx, refMarker, spec, format = "codeblock") {
     var _a;
     const file = this.app.vault.getAbstractFileByPath(ctx.sourcePath);
-    if (!(file instanceof import_obsidian9.TFile))
+    if (!(file instanceof import_obsidian10.TFile))
       return;
-    if (!this.settings.bakeInline)
+    const forced = spec.bake || spec.styleOverride === "native-callout";
+    if (!forced && !this.settings.bakeInline)
       return;
     const { ref, translations, verseNewLine, showVerseNumbers } = spec;
     const transId = translations.length === 1 ? this.resolveTranslationId(translations[0]) : void 0;
@@ -2446,14 +2565,20 @@ var BibleVersePlugin = class extends import_obsidian9.Plugin {
     const verse = await this.fetchVerse(ref, transId, transAbbr, verseNewLine != null ? verseNewLine : void 0, showVerseNumbers != null ? showVerseNumbers : void 0, pb);
     if (!verse)
       return;
+    const opts = format === "callout" ? {
+      format: "callout",
+      calloutType: this.settings.nativeCalloutType,
+      collapsed: spec.calloutCollapsed,
+      url: generateLink(ref, verse.translation, this.settings.preferredWebsite)
+    } : void 0;
     await this.app.vault.process(file, (content) => {
-      return this.baker.bakeVerse(content, refMarker, verse, "inline");
+      return this.baker.bakeVerse(content, refMarker, verse, "inline", opts);
     });
   }
   async codeBlockProcessor(source, el, ctx) {
     var _a;
     el.empty();
-    ctx.addChild(new import_obsidian9.MarkdownRenderChild(el));
+    ctx.addChild(new import_obsidian10.MarkdownRenderChild(el));
     const lines = source.trim().split("\n");
     if (lines.length === 0) {
       renderError(el, "Empty bible code block.");
@@ -2579,7 +2704,7 @@ var BibleVersePlugin = class extends import_obsidian9.Plugin {
   refreshLivePreview() {
     this.app.workspace.iterateAllLeaves((leaf) => {
       var _a;
-      if (leaf.view instanceof import_obsidian9.MarkdownView) {
+      if (leaf.view instanceof import_obsidian10.MarkdownView) {
         const cm = (_a = leaf.view.editor) == null ? void 0 : _a.cm;
         if (cm && cm.dispatch) {
           cm.dispatch({ effects: verseFetchedEffect.of(void 0) });

--- a/src/baker.ts
+++ b/src/baker.ts
@@ -10,6 +10,35 @@ const CODEBLOCK_REGEX = /```bible\s*\n([\s\S]*?)\n```/g;
 
 const CODEBLOCK_BAKE_SEPARATOR = "\n---\n";
 
+/**
+ * Render a verse as native Obsidian callout markdown (a one-way bake).
+ * Every line is quote-prefixed; blank lines become bare ">". The title links
+ * to the source website, and required attribution (e.g. ESV) is appended.
+ * Pure function — exported for testing.
+ */
+export function formatCalloutBake(
+  verse: CachedVerse,
+  calloutType: string,
+  collapsed: boolean,
+  url: string
+): string {
+  const fold = collapsed ? "-" : "+";
+  const title = `[${verse.reference} (${verse.translation})](${url})`;
+  const lines = verse.text.split("\n").map((l) => (l.length > 0 ? `> ${l}` : ">"));
+  if (verse.requireAttribution && verse.copyright) {
+    lines.push(">");
+    lines.push(`> ${verse.copyright}`);
+  }
+  return `> [!${calloutType}]${fold} ${title}\n${lines.join("\n")}`;
+}
+
+export interface InlineBakeOptions {
+  format?: "codeblock" | "callout";
+  calloutType?: string;
+  collapsed?: boolean;
+  url?: string;
+}
+
 export class Baker {
   private app: App;
 
@@ -96,11 +125,14 @@ export class Baker {
    * Bake a verse into the content.
    * If it's an inline reference, it is CONVERTED to a code block.
    */
-  bakeVerse(content: string, refRaw: string, verse: CachedVerse, type: "inline" | "block" = "inline"): string {
+  bakeVerse(content: string, refRaw: string, verse: CachedVerse, type: "inline" | "block" = "inline", opts?: InlineBakeOptions): string {
     if (type === "inline") {
-      // Convert to code block format
-      const block = `\`\`\`bible\n${verse.reference}\ntranslation: ${verse.translation}\n${CODEBLOCK_BAKE_SEPARATOR}${verse.text}\n\`\`\``;
-      return content.replace(refRaw, block);
+      // Convert to a native callout (one-way) or the default ```bible code block.
+      const block = opts?.format === "callout"
+        ? formatCalloutBake(verse, opts.calloutType ?? "quote", opts.collapsed ?? false, opts.url ?? "")
+        : `\`\`\`bible\n${verse.reference}\ntranslation: ${verse.translation}\n${CODEBLOCK_BAKE_SEPARATOR}${verse.text}\n\`\`\``;
+      // Use a replacer function so `$` in verse text isn't treated as a pattern.
+      return content.replace(refRaw, () => block);
     } else {
       // Code block baking
       const separatorIdx = refRaw.indexOf(CODEBLOCK_BAKE_SEPARATOR);

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import { BibleVerseSettingTab } from "./settings";
 import {
   renderVerse,
   renderLink,
+  renderBakePending,
   renderComparison,
   renderError,
 } from "./renderer";
@@ -346,10 +347,26 @@ export default class BibleVersePlugin extends Plugin {
           const span = document.createElement("span");
           span.className = "bible-verse-container";
 
-          if (translations.length >= 2) {
+          const effectiveStyle = spec.styleOverride ?? this.settings.displayStyle;
+          // `bake` token or the native-callout style trigger a one-way bake.
+          const wantsBake = spec.bake || effectiveStyle === "native-callout";
+
+          if (wantsBake && translations.length >= 2) {
+            // Baking a side-by-side comparison isn't supported — render it live.
+            new Notice("Bible Verse: baking isn't supported for multi-translation comparisons.");
             this.renderInlineComparison(span, ref, translations, spec.paragraphBreaks ?? undefined);
+            frag.appendChild(span);
+          } else if (wantsBake) {
+            // Show a placeholder now; the bake rewrites the note on Reading-view render.
+            renderBakePending(span, ref);
+            frag.appendChild(span);
+            this.handleBake(ctx, match[0], spec, effectiveStyle === "native-callout" ? "callout" : "codeblock");
+          } else if (translations.length >= 2) {
+            this.renderInlineComparison(span, ref, translations, spec.paragraphBreaks ?? undefined);
+            frag.appendChild(span);
           } else if (translations.length === 1 && this.isTranslationLinkOnly(translations[0])) {
             renderLink(span, ref, translations[0].toUpperCase(), this.settings.preferredWebsite);
+            frag.appendChild(span);
           } else {
             const translationId = translations.length === 1
               ? this.resolveTranslationId(translations[0])
@@ -358,7 +375,7 @@ export default class BibleVersePlugin extends Plugin {
               ? this.getTranslationAbbr(translationId)
               : this.getTranslationAbbr();
 
-            const style = spec.styleOverride ?? this.settings.displayStyle;
+            const style = effectiveStyle;
             const vnL = spec.verseNewLine ?? this.settings.verseNewLine;
             const sVN = spec.showVerseNumbers ?? this.settings.showVerseNumbers;
             const pb = spec.paragraphBreaks ?? this.settings.paragraphBreaks;
@@ -370,12 +387,12 @@ export default class BibleVersePlugin extends Plugin {
               renderLink(span, ref, abbr, this.settings.preferredWebsite);
               this.fetchAndRenderWithTranslation(span, ref, translationId, abbr, style, vnL, sVN, pb);
             }
-          }
 
-          frag.appendChild(span);
+            frag.appendChild(span);
 
-          if (this.settings.persistVerseText && translations.length === 0) {
-            this.handleBake(ctx, match[0], spec);
+            if (this.settings.persistVerseText && translations.length === 0) {
+              this.handleBake(ctx, match[0], spec);
+            }
           }
         } else {
           frag.appendChild(document.createTextNode(match[0]));
@@ -462,12 +479,16 @@ export default class BibleVersePlugin extends Plugin {
   private async handleBake(
     ctx: MarkdownPostProcessorContext,
     refMarker: string,
-    spec: InlineSpec
+    spec: InlineSpec,
+    format: "codeblock" | "callout" = "codeblock"
   ): Promise<void> {
     const file = this.app.vault.getAbstractFileByPath(ctx.sourcePath);
     if (!(file instanceof TFile)) return;
 
-    if (!this.settings.bakeInline) return;
+    // Forced bakes (the `bake` token / native-callout style) bypass the global
+    // "Bake inline references" gate; the passive persist path still respects it.
+    const forced = spec.bake || spec.styleOverride === "native-callout";
+    if (!forced && !this.settings.bakeInline) return;
 
     const { ref, translations, verseNewLine, showVerseNumbers } = spec;
     const transId = translations.length === 1 ? this.resolveTranslationId(translations[0]) : undefined;
@@ -477,8 +498,17 @@ export default class BibleVersePlugin extends Plugin {
     const verse = await this.fetchVerse(ref, transId, transAbbr, verseNewLine ?? undefined, showVerseNumbers ?? undefined, pb);
     if (!verse) return;
 
+    const opts = format === "callout"
+      ? {
+          format: "callout" as const,
+          calloutType: this.settings.nativeCalloutType,
+          collapsed: spec.calloutCollapsed,
+          url: generateLink(ref, verse.translation, this.settings.preferredWebsite),
+        }
+      : undefined;
+
     await this.app.vault.process(file, (content) => {
-      return this.baker.bakeVerse(content, refMarker, verse, "inline");
+      return this.baker.bakeVerse(content, refMarker, verse, "inline", opts);
     });
   }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -134,6 +134,10 @@ export interface InlineSpec {
   verseNewLine: boolean | null;
   showVerseNumbers: boolean | null;
   paragraphBreaks: boolean | null;
+  /** `bake` token: force a one-way bake of this reference on render. */
+  bake: boolean;
+  /** For the native-callout style: bake the callout collapsed (`nco-`). */
+  calloutCollapsed: boolean;
 }
 
 /** A translation code is word-chars only and must start with a letter. */
@@ -145,6 +149,7 @@ export const KNOWN_STYLES: readonly DisplayStyle[] = [
   "callout",
   "blockquote",
   "inline",
+  "native-callout",
 ];
 
 function isKnownStyle(token: string): token is DisplayStyle {
@@ -175,6 +180,8 @@ export function parseInlineSpec(content: string): InlineSpec | null {
       verseNewLine: null,
       showVerseNumbers: null,
       paragraphBreaks: null,
+      bake: false,
+      calloutCollapsed: false,
     };
   }
 
@@ -187,11 +194,30 @@ export function parseInlineSpec(content: string): InlineSpec | null {
   let verseNewLine: boolean | null = null;
   let showVerseNumbers: boolean | null = null;
   let paragraphBreaks: boolean | null = null;
+  let bake = false;
+  let calloutCollapsed = false;
   let cut = parts.length;
 
   while (cut > 1) {
     const tok = parts[cut - 1];
     const low = tok.toLowerCase();
+
+    // `bake` — force a one-way bake into a ```bible code block.
+    if (low === "bake") {
+      bake = true;
+      cut--;
+      continue;
+    }
+
+    // Native callout style, incl. `nco` alias and optional +/- fold marker.
+    const ncMatch = low.match(/^(?:native-callout|nco)([+-])?$/);
+    if (ncMatch) {
+      if (styleOverride !== null) break;
+      styleOverride = "native-callout";
+      calloutCollapsed = ncMatch[1] === "-";
+      cut--;
+      continue;
+    }
 
     // Check for formatting flags
     if (low === "nl") {
@@ -249,7 +275,7 @@ export function parseInlineSpec(content: string): InlineSpec | null {
   const ref = parseReference(refStr);
   if (!ref) return null;
 
-  return { ref, translations, styleOverride, verseNewLine, showVerseNumbers, paragraphBreaks };
+  return { ref, translations, styleOverride, verseNewLine, showVerseNumbers, paragraphBreaks, bake, calloutCollapsed };
 }
 
 /**

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -191,6 +191,19 @@ export function renderLink(
 }
 
 /**
+ * Render a placeholder pill for a reference that will be baked (one-way) into
+ * the note the next time it renders in Reading view. Shown in the editor / Live
+ * Preview, where we don't write to the file.
+ */
+export function renderBakePending(container: HTMLElement, ref: BibleReference): void {
+  const refStr = formatReference(ref);
+  const pill = container.createSpan({ cls: "bible-verse-pill bible-verse-bake-pending" });
+  const iconSpan = pill.createSpan({ cls: "bible-verse-icon" });
+  setIcon(iconSpan, "save");
+  pill.createSpan({ text: `${refStr} — will bake` });
+}
+
+/**
  * Render a comparison/parallel view of multiple translations.
  */
 export async function renderComparison(

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -72,9 +72,30 @@ export class BibleVerseSettingTab extends PluginSettingTab {
           .addOption("callout", "Callout")
           .addOption("blockquote", "Blockquote")
           .addOption("inline", "Inline")
+          .addOption("native-callout", "Native callout (bakes into note)")
           .setValue(this.plugin.settings.displayStyle)
           .onChange(async (value) => {
             this.plugin.settings.displayStyle = value as DisplayStyle;
+            await this.plugin.saveSettings();
+          })
+      );
+
+    containerEl.createEl("p", {
+      cls: "bible-verse-settings-note",
+      text:
+        "“Bake” means writing a verse’s text permanently into your note as ordinary Markdown, so it reads without the plugin. The {…, bake} token bakes to a code block; the “Native callout” style (or {…, native-callout} / {…, nco}) bakes to a real, collapsible Obsidian callout. Baking is one-way — the plugin stops tracking it afterward. Note: choosing “Native callout” as your default here will auto-bake every scripture reference you add.",
+    });
+
+    // Native Callout Type
+    new Setting(containerEl)
+      .setName("Native callout type")
+      .setDesc(df("Callout type used when baking as a native callout — match a type your theme or icon pack styles.", "quote", "bible"))
+      .addText((text) =>
+        text
+          .setPlaceholder("quote")
+          .setValue(this.plugin.settings.nativeCalloutType)
+          .onChange(async (value) => {
+            this.plugin.settings.nativeCalloutType = value.trim() || "quote";
             await this.plugin.saveSettings();
           })
       );

--- a/src/suggest.ts
+++ b/src/suggest.ts
@@ -111,10 +111,14 @@ export class BibleReferenceSuggest extends EditorSuggest<BibleSuggestion> {
                 suggestions.push(`${prefix}, ${style}`);
               }
             }
+            // `nco` is a short alias for the native-callout style.
+            if ("nco".startsWith(modPart)) {
+              suggestions.push(`${prefix}, nco`);
+            }
           }
 
           // Suggest formatting flags
-          const flags = ["nl", "no-nl", "v", "no-v", "para", "no-para"];
+          const flags = ["nl", "no-nl", "v", "no-v", "para", "no-para", "bake"];
           for (const flag of flags) {
             if (flag.startsWith(modPart)) {
               suggestions.push(`${prefix}, ${flag}`);
@@ -137,6 +141,8 @@ export class BibleReferenceSuggest extends EditorSuggest<BibleSuggestion> {
             { value: `${refStr}, sidebar`, label: "Sidebar" },
             { value: `${refStr}, blockquote`, label: "Blockquote" },
             { value: `${refStr}, inline`, label: "Inline" },
+            { value: `${refStr}, native-callout`, label: "Native callout (bakes into note)" },
+            { value: `${refStr}, bake`, label: "Bake into note" },
             { value: `${refStr}, nl`, label: "New line per verse" },
             { value: `${refStr}, no-nl`, label: "Single paragraph" },
             { value: `${refStr}, no-v`, label: "Hide verse numbers" },

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,7 @@ export interface BibleReference {
   raw: string;
 }
 
-export type DisplayStyle = "sidebar" | "callout" | "blockquote" | "inline";
+export type DisplayStyle = "sidebar" | "callout" | "blockquote" | "inline" | "native-callout";
 
 export type BibleWebsite = "BibleHub" | "BibleGateway" | "BlueLetter" | "BibleCom";
 
@@ -29,6 +29,8 @@ export interface BibleVerseSettings {
   paragraphBreaks: boolean;
   helperMode: boolean;
   esvApiKey: string;
+  /** Callout type used when baking as a native callout (e.g. "quote", "bible"). */
+  nativeCalloutType: string;
 }
 
 export const DEFAULT_SETTINGS: BibleVerseSettings = {
@@ -44,6 +46,7 @@ export const DEFAULT_SETTINGS: BibleVerseSettings = {
   paragraphBreaks: false,
   helperMode: true,
   esvApiKey: "",
+  nativeCalloutType: "quote",
 };
 
 /** Cached verse entry */

--- a/src/view-plugin.ts
+++ b/src/view-plugin.ts
@@ -11,7 +11,7 @@ import { setIcon } from "obsidian";
 import type BibleVersePlugin from "./main";
 import { parseInlineSpec, formatReference } from "./parser";
 import { BibleReference, CachedVerse, DisplayStyle, BibleWebsite } from "./types";
-import { renderVerse, renderComparison, renderError } from "./renderer";
+import { renderVerse, renderComparison, renderError, renderBakePending } from "./renderer";
 import { verseFetchedEffect } from "./effects";
 
 // Matches {…} inline tokens (same pattern as inlinePostProcessor)
@@ -31,6 +31,7 @@ class BibleVerseWidget extends WidgetType {
       verseNewLine: boolean | null;
       showVerseNumbers: boolean | null;
       paragraphBreaks: boolean | null;
+      bake: boolean;
       cachedVerses: CachedVerse[];
       preferredWebsite: BibleWebsite;
       plugin: BibleVersePlugin;
@@ -46,6 +47,14 @@ class BibleVerseWidget extends WidgetType {
     const vnL = this.spec.verseNewLine ?? this.spec.plugin.settings.verseNewLine;
     const sVN = this.spec.showVerseNumbers ?? this.spec.plugin.settings.showVerseNumbers;
     const pb = this.spec.paragraphBreaks ?? this.spec.plugin.settings.paragraphBreaks;
+
+    // References that bake (the `bake` token or native-callout style) show a
+    // placeholder in the editor; the actual bake happens on Reading-view render.
+    const effectiveStyle = this.spec.styleOverride ?? this.spec.plugin.settings.displayStyle;
+    if ((this.spec.bake || effectiveStyle === "native-callout") && this.spec.translations.length < 2) {
+      renderBakePending(container, this.spec.ref);
+      return container;
+    }
 
     if (this.spec.translations.length === 1 && this.spec.plugin.isTranslationLinkOnly(this.spec.translations[0])) {
       this.renderPill(container);
@@ -182,6 +191,7 @@ class BibleVerseWidget extends WidgetType {
       this.spec.verseNewLine === other.spec.verseNewLine &&
       this.spec.showVerseNumbers === other.spec.showVerseNumbers &&
       this.spec.paragraphBreaks === other.spec.paragraphBreaks &&
+      this.spec.bake === other.spec.bake &&
       this.spec.preferredWebsite === other.spec.preferredWebsite
     );
   }
@@ -251,7 +261,7 @@ export function buildViewPlugin(plugin: BibleVersePlugin) {
             const spec = parseInlineSpec(content);
             if (!spec) continue;
 
-            const { ref, translations, styleOverride, verseNewLine, showVerseNumbers, paragraphBreaks } = spec;
+            const { ref, translations, styleOverride, verseNewLine, showVerseNumbers, paragraphBreaks, bake } = spec;
             const refLabel = formatReference(ref);
             const vnL = verseNewLine ?? plugin.settings.verseNewLine;
             const sVN = showVerseNumbers ?? plugin.settings.showVerseNumbers;
@@ -298,6 +308,7 @@ export function buildViewPlugin(plugin: BibleVersePlugin) {
               verseNewLine,
               showVerseNumbers,
               paragraphBreaks,
+              bake,
               cachedVerses,
               preferredWebsite: plugin.settings.preferredWebsite,
               plugin,

--- a/styles.css
+++ b/styles.css
@@ -172,6 +172,12 @@
   color: var(--text-accent);
 }
 
+/* Placeholder shown in the editor for a reference that will bake on read. */
+.bible-verse-bake-pending {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
 /* ========================
    Error
    ======================== */

--- a/test/callout-bake.test.ts
+++ b/test/callout-bake.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { formatCalloutBake } from "../src/baker";
+import type { CachedVerse } from "../src/types";
+
+function verse(partial: Partial<CachedVerse>): CachedVerse {
+  return {
+    reference: "John 3:16",
+    translation: "KJV",
+    bibleId: "eng_kjv",
+    text: "For God so loved the world...",
+    copyright: "",
+    fetchedAt: 0,
+    ...partial,
+  };
+}
+
+const URL = "https://www.biblegateway.com/passage/?search=John+3%3A16&version=KJV";
+
+describe("formatCalloutBake", () => {
+  it("single verse, expanded, linked title", () => {
+    expect(formatCalloutBake(verse({}), "quote", false, URL)).toMatchInlineSnapshot(`
+      "> [!quote]+ [John 3:16 (KJV)](https://www.biblegateway.com/passage/?search=John+3%3A16&version=KJV)
+      > For God so loved the world..."
+    `);
+  });
+
+  it("collapsed uses the '-' fold marker", () => {
+    expect(formatCalloutBake(verse({}), "quote", true, URL).split("\n")[0]).toBe(
+      "> [!quote]- [John 3:16 (KJV)](https://www.biblegateway.com/passage/?search=John+3%3A16&version=KJV)"
+    );
+  });
+
+  it("custom callout type", () => {
+    expect(formatCalloutBake(verse({}), "bible", false, URL).split("\n")[0]).toContain("[!bible]+");
+  });
+
+  it("multi-line text is quote-prefixed per line", () => {
+    const v = verse({ reference: "John 3:16-17", text: "16. For God so loved...\n17. For God sent not..." });
+    expect(formatCalloutBake(v, "quote", false, URL)).toBe(
+      `> [!quote]+ [John 3:16-17 (KJV)](${URL})\n> 16. For God so loved...\n> 17. For God sent not...`
+    );
+  });
+
+  it("blank lines (paragraph breaks) become bare '>'", () => {
+    const v = verse({ text: "verse one\n\nverse two" });
+    expect(formatCalloutBake(v, "quote", false, URL)).toBe(
+      `> [!quote]+ [John 3:16 (KJV)](${URL})\n> verse one\n>\n> verse two`
+    );
+  });
+
+  it("appends required attribution (e.g. ESV) as a trailing quote block", () => {
+    const v = verse({
+      reference: "John 11:35",
+      translation: "ESV",
+      text: "Jesus wept.",
+      copyright: "The Holy Bible, ESV® ... © 2001 by Crossway.",
+      requireAttribution: true,
+    });
+    expect(formatCalloutBake(v, "quote", false, URL)).toBe(
+      `> [!quote]+ [John 11:35 (ESV)](${URL})\n> Jesus wept.\n>\n> The Holy Bible, ESV® ... © 2001 by Crossway.`
+    );
+  });
+
+  it("omits attribution when not required", () => {
+    const v = verse({ copyright: "License: https://example.com", requireAttribution: false });
+    expect(formatCalloutBake(v, "quote", false, URL)).not.toContain("License:");
+  });
+});

--- a/test/parse-tokens.test.ts
+++ b/test/parse-tokens.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { parseInlineSpec } from "../src/parser";
+
+describe("parseInlineSpec — bake & native-callout tokens", () => {
+  it("plain reference has bake=false, calloutCollapsed=false", () => {
+    const s = parseInlineSpec("John 3:16")!;
+    expect(s.bake).toBe(false);
+    expect(s.calloutCollapsed).toBe(false);
+    expect(s.styleOverride).toBeNull();
+  });
+
+  it("`bake` token sets bake=true", () => {
+    const s = parseInlineSpec("John 3:16, bake")!;
+    expect(s.bake).toBe(true);
+    expect(s.styleOverride).toBeNull();
+  });
+
+  it("`native-callout` sets the style, expanded by default", () => {
+    const s = parseInlineSpec("John 3:16, native-callout")!;
+    expect(s.styleOverride).toBe("native-callout");
+    expect(s.calloutCollapsed).toBe(false);
+  });
+
+  it("`nco` is an alias for native-callout", () => {
+    expect(parseInlineSpec("John 3:16, nco")!.styleOverride).toBe("native-callout");
+  });
+
+  it("`nco-` / `native-callout-` bake collapsed", () => {
+    expect(parseInlineSpec("John 3:16, nco-")!.calloutCollapsed).toBe(true);
+    expect(parseInlineSpec("John 3:16, native-callout-")!.calloutCollapsed).toBe(true);
+  });
+
+  it("`nco+` is explicitly expanded", () => {
+    const s = parseInlineSpec("John 3:16, nco+")!;
+    expect(s.styleOverride).toBe("native-callout");
+    expect(s.calloutCollapsed).toBe(false);
+  });
+
+  it("combines with a translation", () => {
+    const s = parseInlineSpec("John 3:16, ESV, nco-")!;
+    expect(s.translations).toEqual(["ESV"]);
+    expect(s.styleOverride).toBe("native-callout");
+    expect(s.calloutCollapsed).toBe(true);
+  });
+
+  it("combines `bake` with a translation", () => {
+    const s = parseInlineSpec("John 3:16, KJV, bake")!;
+    expect(s.translations).toEqual(["KJV"]);
+    expect(s.bake).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a one-way **bake** render path: a `{ref}` can be written permanently into the note as real Markdown, after which the plugin stops tracking it (it's just text you own). This is how we deliver a **collapsible callout** — by handing rendering back to Obsidian rather than reinventing fold behavior, so it inherits the user's theme, icon packs, and native folding.

## New tokens / style

- **`native-callout`** (alias **`nco`**) — bakes into a genuine Obsidian callout: `> [!quote]+ [John 3:16 (KJV)](…)`. Add `-` to start collapsed (`nco-`), `+` to force expanded. Also selectable as a **Display style** default.
- **`bake`** — bakes into the existing ```bible code block, ignoring the global "Bake inline references" gate.

## Behavior

- Baking fires on **Reading-view render**; in the editor / Live Preview a **"will bake" pill** is shown (we never write to the file mid-edit).
- **One-way:** once baked, the reference is real Markdown — no tracking, refresh, or strip.
- **Callout type** is configurable (default `quote`) so icon-pack users can target e.g. `[!bible]`.
- **ESV attribution** is written into the baked callout body (required by Crossway's license).
- **Comparisons** (2+ translations) aren't baked — skipped with a notice.
- Settings gain a "Native callout type" field and a subscript explaining that baking writes permanent text, and that choosing Native callout as the default auto-bakes every reference.

## Design decisions (agreed up front)

| Decision | Choice |
|---|---|
| Live-Preview fold risk | Sidestepped — native-callout is *baked* real Markdown, not a widget, so Obsidian folds it natively everywhere |
| Fold default | Expanded + collapsible (`[!quote]+`); `nco-` for collapsed |
| Tracking | One-way (baked = your content) |
| Title | Linked to preferred Bible site |

## Testing

- `npm test` → **36/36 green** (5 files). New coverage: `formatCalloutBake` (single/multi-line/poetry/attribution/collapsed/type) and the parser tokens (`bake`, `native-callout`, `nco`, `nco-`, `nco+`, combined with translations).
- Verified in real Obsidian: `nco-` bakes a collapsed callout, `bake` bakes a code block, the "will bake" pill shows in Live Preview and converts on Reading-view render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)