### PR TITLE
ci: add release workflow with build-provenance attestation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+name: Release
+
+# Builds the plugin in CI on a version-tag push and publishes a GitHub release
+# with attested build provenance for the compiled artifacts. Because provenance
+# attestations are tied to the workflow's OIDC identity, releases must be built
+# here (not locally) for `gh attestation verify` to succeed.
+#
+# To cut a release: bump manifest.json, commit, then push a tag matching the
+# version, e.g.  git tag 1.6.6 && git push origin 1.6.6
+
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: write        # create the release
+  id-token: write        # OIDC token for provenance
+  attestations: write    # write the attestation
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify manifest.json version matches the tag
+        run: |
+          MANIFEST_VERSION="$(node -p "require('./manifest.json').version")"
+          if [ "$MANIFEST_VERSION" != "$GITHUB_REF_NAME" ]; then
+            echo "::error::manifest.json version ($MANIFEST_VERSION) does not match tag ($GITHUB_REF_NAME)"
+            exit 1
+          fi
+
+      - name: Build
+        run: npm run build
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            main.js
+            styles.css
+
+      - name: Publish release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >
+          gh release create "$GITHUB_REF_NAME"
+          --title "$GITHUB_REF_NAME"
+          --generate-notes
+          main.js manifest.json styles.css

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+# Vitest 4's optional `@types/node` peer range conflicts with the plugin's
+# pinned @types/node@16, so installs (including `npm ci` in CI) need this.
+legacy-peer-deps=true


### PR DESCRIPTION
## Summary

Addresses the "missing artifact attestations" recommendation by moving release builds into GitHub Actions and attesting the compiled artifacts.

Artifact attestations are tied to the workflow's OIDC identity, so they **can only be generated in CI** — a locally-built binary can't be attested after the fact. This adds a release workflow so future releases carry verifiable [build provenance](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds).

## What it does

`.github/workflows/release.yml`, triggered on a version-tag push (`1.6.6`, etc.):
1. `npm ci` + build the plugin
2. **verify** `manifest.json` version matches the tag (guards against mismatched releases)
3. `actions/attest-build-provenance` on `main.js` and `styles.css`
4. publish the GitHub release with `main.js`, `manifest.json`, `styles.css`

Permissions: `contents: write`, `id-token: write`, `attestations: write`.

Users can then verify:
```
gh attestation verify main.js --repo kilrkrow/obsidian-bible-verse
```

## Also

- `.npmrc` with `legacy-peer-deps=true` so `npm ci` tolerates Vitest 4's optional `@types/node` peer range vs the pinned `@types/node@16`.

## Notes

- **New release ritual:** bump `manifest.json`, commit, then `git tag <version> && git push origin <version>` — CI builds, attests, and publishes. (Replaces the manual local build + `gh release create`.)
- **1.6.5 is left as-is** (built locally, can't be retroactively attested); attestation applies from the next tag onward.
- Validated locally: `npm ci`, the version-check, and `npm run build` all succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)