### PR TITLE
ci: trigger release workflow on published release (fits web releasing)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,20 @@
 name: Release
 
-# Builds the plugin in CI on a version-tag push and publishes a GitHub release
-# with attested build provenance for the compiled artifacts. Because provenance
-# attestations are tied to the workflow's OIDC identity, releases must be built
-# here (not locally) for `gh attestation verify` to succeed.
+# Attaches an attested, CI-built plugin bundle to a GitHub release.
 #
-# To cut a release: bump manifest.json, commit, then push a tag matching the
-# version, e.g.  git tag 1.6.6 && git push origin 1.6.6
+# Release from the GitHub website: bump manifest.json (commit to main), then
+# Releases -> "Draft a new release" -> create a new tag matching the version
+# (e.g. 1.6.6), target main, and Publish. You do NOT need to attach any files —
+# this workflow builds them in CI, attests their provenance, and uploads them.
+# Because provenance is tied to the workflow's OIDC identity, the artifacts must
+# be built here (not locally) for `gh attestation verify` to succeed.
 
 on:
-  push:
-    tags:
-      - "[0-9]+.[0-9]+.[0-9]+"
+  release:
+    types: [published]
 
 permissions:
-  contents: write        # create the release
+  contents: write        # upload release assets
   id-token: write        # OIDC token for provenance
   attestations: write    # write the attestation
 
@@ -22,8 +22,10 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout the released tag
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -34,11 +36,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Verify manifest.json version matches the tag
+      - name: Verify manifest.json version matches the release tag
         run: |
           MANIFEST_VERSION="$(node -p "require('./manifest.json').version")"
-          if [ "$MANIFEST_VERSION" != "$GITHUB_REF_NAME" ]; then
-            echo "::error::manifest.json version ($MANIFEST_VERSION) does not match tag ($GITHUB_REF_NAME)"
+          TAG="${{ github.event.release.tag_name }}"
+          if [ "$MANIFEST_VERSION" != "$TAG" ]; then
+            echo "::error::manifest.json version ($MANIFEST_VERSION) does not match release tag ($TAG)"
             exit 1
           fi
 
@@ -52,11 +55,9 @@ jobs:
             main.js
             styles.css
 
-      - name: Publish release
+      - name: Upload assets to the release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: >
-          gh release create "$GITHUB_REF_NAME"
-          --title "$GITHUB_REF_NAME"
-          --generate-notes
-          main.js manifest.json styles.css
+          gh release upload "${{ github.event.release.tag_name }}"
+          main.js manifest.json styles.css --clobber


### PR DESCRIPTION
## Why

PR #32 shipped the release workflow with a **tag-push** trigger (`on: push: tags`) that also runs `gh release create`. That doesn't fit releasing from the **GitHub website**: the browser has no "create a bare tag" button — the only way to make a tag in the UI is to publish a release. So on a web release the workflow either doesn't fire or tries to create a release that already exists → the attested assets never get attached.

## Fix

Switch the trigger to **`on: release: [published]`**. Now the flow is:

1. Bump `manifest.json`, commit to `main`.
2. On GitHub: **Releases → Draft a new release →** create a new tag matching the version (e.g. `1.6.6`), target `main`, **Publish**. No need to attach any files.
3. The workflow checks out the tag, verifies `manifest.json` version == tag, builds, runs `attest-build-provenance` on `main.js`/`styles.css`, and uploads `main.js`/`manifest.json`/`styles.css` to the release with `--clobber`.

Same attestation guarantees as before, just triggered by the release you publish rather than a tag you push from the CLI.

## Note

Merge this **before** publishing the 1.6.6 release so the corrected workflow is the one that runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)