### PR TITLE
fix: declare @codemirror/state and @codemirror/view as devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.6.3",
       "license": "GPL-3.0",
       "devDependencies": {
+        "@codemirror/state": "^6.7.0",
+        "@codemirror/view": "^6.43.4",
         "@types/node": "^16.11.6",
         "esbuild": "0.17.3",
         "jsdom": "^29.1.1",
@@ -80,6 +82,29 @@
       },
       "bin": {
         "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.0.tgz",
+      "integrity": "sha512-Zbl9NyscLMZkfXPQnNAIIAFftidrA1UbcJEIMp24C0Bukc2I5T8wJS0wsXYsnDOqCFJUeJ1BITGNs5CqPDSmSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.43.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.4.tgz",
+      "integrity": "sha512-YImu23iyKfncJzT7sRy+rEqEhSc8RhOHqDxwy4WzXRKJwYm6iwf/9OJk5ctCAdZ6yi2ZqaGEvmf55fSVqMDrgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.7.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -655,6 +680,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz",
+      "integrity": "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
@@ -1183,6 +1215,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/crelt": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
+      "integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1928,6 +1967,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -2223,6 +2269,13 @@
           "optional": false
         }
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   ],
   "license": "GPL-3.0",
   "devDependencies": {
+    "@codemirror/state": "^6.7.0",
+    "@codemirror/view": "^6.43.4",
     "@types/node": "^16.11.6",
     "esbuild": "0.17.3",
     "jsdom": "^29.1.1",


### PR DESCRIPTION
## Why the 1.6.6 release build failed

The release workflow ran on the 1.6.6 publish and failed at `npm run build`:

```
Cannot find module '@codemirror/view' or its corresponding type declarations.
Cannot find module '@codemirror/state' or its corresponding type declarations.
```

`src/main.ts`, `src/view-plugin.ts`, and `src/effects.ts` import from `@codemirror/view` and `@codemirror/state`, but those packages were **never declared in `package.json`**. They only existed in local `node_modules` (hoisted from the parent repo), so local builds worked — while a clean `npm ci` in CI didn't install them, so `tsc` couldn't find the type declarations.

## Fix

Declare both as devDependencies (`^6.0.0`). They're types-only for the build — `esbuild.config.mjs` already lists all `@codemirror/*` as `external` since Obsidian provides CodeMirror at runtime, so nothing new gets bundled.

Validated with a clean `npm ci` + `npm run build` (the exact CI steps) — both pass.

## After merge — re-cut 1.6.6

The `1.6.6` tag points at the commit *before* this fix, so re-running the failed workflow would rebuild the same broken tree. To get a working, attested 1.6.6:

1. Merge this PR.
2. Delete the failed **1.6.6 release and tag**.
3. Re-publish the **1.6.6** release on the web (new tag at the fixed `main` tip) → the workflow builds, attests, and uploads the assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)