### PR TITLE
chore: address Obsidian plugin-review lint findings

### DIFF
--- a/main.js
+++ b/main.js
@@ -1220,11 +1220,11 @@ function addFeedbackSetting(containerEl, pluginVersion) {
 
 // src/settings.ts
 function df(text, ...examples) {
-  const frag = document.createDocumentFragment();
-  frag.appendChild(document.createTextNode(text));
+  const frag = activeDocument.createDocumentFragment();
+  frag.appendChild(activeDocument.createTextNode(text));
   for (const ex of examples) {
-    frag.appendChild(document.createTextNode(" "));
-    const code = document.createElement("code");
+    frag.appendChild(activeDocument.createTextNode(" "));
+    const code = activeDocument.createElement("code");
     code.textContent = ex;
     frag.appendChild(code);
   }
@@ -1271,7 +1271,7 @@ var BibleVerseSettingTab = class extends import_obsidian4.PluginSettingTab {
       })
     );
     new import_obsidian4.Setting(containerEl).setName("Sidebar top padding").setDesc("Adjust the top spacing for the Sidebar style (in ems)").addSlider(
-      (slider) => slider.setLimits(0, 2, 0.1).setValue(this.plugin.settings.sidebarTopPadding).setDynamicTooltip().onChange(async (value) => {
+      (slider) => slider.setLimits(0, 2, 0.1).setValue(this.plugin.settings.sidebarTopPadding).onChange(async (value) => {
         this.plugin.settings.sidebarTopPadding = value;
         await this.plugin.saveSettings();
         this.plugin.updateStyles();
@@ -1464,7 +1464,7 @@ function flattenInlineContent(container, verseNewLine) {
       container.insertBefore(p.firstChild, p);
     }
     if (i < paragraphs.length - 1) {
-      const sep = document.createElement("span");
+      const sep = activeDocument.createElement("span");
       sep.className = "bible-verse-para-break";
       container.insertBefore(sep, p);
     }
@@ -1476,11 +1476,11 @@ function flattenInlineContent(container, verseNewLine) {
       next.data = next.data.slice(1);
     }
     if (verseNewLine) {
-      const lineBreak = document.createElement("span");
+      const lineBreak = activeDocument.createElement("span");
       lineBreak.className = "bible-verse-line-break";
       br.replaceWith(lineBreak);
     } else {
-      br.replaceWith(document.createTextNode(" "));
+      br.replaceWith(activeDocument.createTextNode(" "));
     }
   }
 }
@@ -1910,13 +1910,11 @@ var BibleVerseWidget = class extends import_view.WidgetType {
     this.spec = spec;
   }
   toDOM(view) {
-    var _a, _b, _c, _d, _e, _f;
-    const container = document.createElement("span");
+    var _a, _b, _c, _d;
+    const container = activeDocument.createElement("span");
     container.className = "bible-verse-livepreview";
     const vnL = (_a = this.spec.verseNewLine) != null ? _a : this.spec.plugin.settings.verseNewLine;
-    const sVN = (_b = this.spec.showVerseNumbers) != null ? _b : this.spec.plugin.settings.showVerseNumbers;
-    const pb = (_c = this.spec.paragraphBreaks) != null ? _c : this.spec.plugin.settings.paragraphBreaks;
-    const effectiveStyle = (_d = this.spec.styleOverride) != null ? _d : this.spec.plugin.settings.displayStyle;
+    const effectiveStyle = (_b = this.spec.styleOverride) != null ? _b : this.spec.plugin.settings.displayStyle;
     if ((this.spec.bake || effectiveStyle === "native-callout") && this.spec.translations.length < 2) {
       renderBakePending(container, this.spec.ref);
       return container;
@@ -1927,7 +1925,7 @@ var BibleVerseWidget = class extends import_view.WidgetType {
     }
     if (this.spec.translations.length >= 2) {
       if (this.spec.cachedVerses.length === this.spec.translations.length) {
-        renderComparison(
+        void renderComparison(
           container,
           this.spec.ref,
           this.spec.cachedVerses,
@@ -1938,32 +1936,32 @@ var BibleVerseWidget = class extends import_view.WidgetType {
         );
       } else {
         this.renderPill(container);
-        this.fetchAndUpdate(container, view);
+        void this.fetchAndUpdate(container, view);
       }
     } else {
       const cached = this.spec.cachedVerses[0];
       if (cached) {
-        renderVerse(
+        void renderVerse(
           container,
           this.spec.ref,
           cached,
-          (_e = this.spec.styleOverride) != null ? _e : this.spec.plugin.settings.displayStyle,
+          (_c = this.spec.styleOverride) != null ? _c : this.spec.plugin.settings.displayStyle,
           this.spec.preferredWebsite,
           this.spec.plugin.settings.showAttribution,
           this.spec.plugin.app,
           this.spec.plugin,
-          (_f = this.spec.paragraphBreaks) != null ? _f : this.spec.plugin.settings.paragraphBreaks,
+          (_d = this.spec.paragraphBreaks) != null ? _d : this.spec.plugin.settings.paragraphBreaks,
           vnL
         );
       } else {
         this.renderPill(container);
-        this.fetchAndUpdate(container, view);
+        void this.fetchAndUpdate(container, view);
       }
     }
     return container;
   }
   renderPill(container) {
-    const a = document.createElement("a");
+    const a = activeDocument.createElement("a");
     a.className = "bible-verse-pill";
     const iconSpan = a.createSpan({ cls: "bible-verse-icon" });
     (0, import_obsidian8.setIcon)(iconSpan, "book-open");
@@ -2308,7 +2306,7 @@ var BibleVersePlugin = class extends import_obsidian10.Plugin {
           new import_obsidian10.Notice("No text selected.");
           return;
         }
-        navigator.clipboard.writeText(selection.trim());
+        void navigator.clipboard.writeText(selection.trim());
         new import_obsidian10.Notice("Copied to clipboard. Opening search...");
         const abbr = this.getTranslationAbbr();
         const url = generateSearchUrl(selection.trim(), abbr, this.settings.preferredWebsite);
@@ -2346,10 +2344,11 @@ var BibleVersePlugin = class extends import_obsidian10.Plugin {
     });
   }
   async loadSettings() {
-    this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+    const saved = await this.loadData();
+    this.settings = Object.assign({}, DEFAULT_SETTINGS, saved);
   }
   updateStyles() {
-    document.body.style.setProperty(
+    activeDocument.body.style.setProperty(
       "--bible-verse-sidebar-top-padding",
       `${this.settings.sidebarTopPadding}em`
     );
@@ -2429,7 +2428,7 @@ var BibleVersePlugin = class extends import_obsidian10.Plugin {
   async inlinePostProcessor(el, ctx) {
     var _a, _b, _c, _d, _e, _f, _g;
     const INLINE_REGEX = /\{([A-Za-z0-9][^}\n]*)\}/g;
-    const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+    const walker = activeDocument.createTreeWalker(el, NodeFilter.SHOW_TEXT);
     const nodesToProcess = [];
     let node;
     while (node = walker.nextNode()) {
@@ -2441,31 +2440,31 @@ var BibleVersePlugin = class extends import_obsidian10.Plugin {
     }
     for (const { node: node2, matches } of nodesToProcess) {
       const text = node2.textContent || "";
-      const frag = document.createDocumentFragment();
+      const frag = activeDocument.createDocumentFragment();
       let lastIndex = 0;
       for (const match of matches) {
         const matchIndex = match.index;
         if (matchIndex > lastIndex) {
-          frag.appendChild(document.createTextNode(text.slice(lastIndex, matchIndex)));
+          frag.appendChild(activeDocument.createTextNode(text.slice(lastIndex, matchIndex)));
         }
         const rawContent = match[1].trim();
         const spec = parseInlineSpec(rawContent);
         if (spec) {
           const { ref, translations } = spec;
-          const span = document.createElement("span");
+          const span = activeDocument.createElement("span");
           span.className = "bible-verse-container";
           const effectiveStyle = (_a = spec.styleOverride) != null ? _a : this.settings.displayStyle;
           const wantsBake = spec.bake || effectiveStyle === "native-callout";
           if (wantsBake && translations.length >= 2) {
             new import_obsidian10.Notice("Bible Verse: baking isn't supported for multi-translation comparisons.");
-            this.renderInlineComparison(span, ref, translations, (_b = spec.paragraphBreaks) != null ? _b : void 0);
+            void this.renderInlineComparison(span, ref, translations, (_b = spec.paragraphBreaks) != null ? _b : void 0);
             frag.appendChild(span);
           } else if (wantsBake) {
             renderBakePending(span, ref);
             frag.appendChild(span);
-            this.handleBake(ctx, match[0], spec, effectiveStyle === "native-callout" ? "callout" : "codeblock");
+            void this.handleBake(ctx, match[0], spec, effectiveStyle === "native-callout" ? "callout" : "codeblock");
           } else if (translations.length >= 2) {
-            this.renderInlineComparison(span, ref, translations, (_c = spec.paragraphBreaks) != null ? _c : void 0);
+            void this.renderInlineComparison(span, ref, translations, (_c = spec.paragraphBreaks) != null ? _c : void 0);
             frag.appendChild(span);
           } else if (translations.length === 1 && this.isTranslationLinkOnly(translations[0])) {
             renderLink(span, ref, translations[0].toUpperCase(), this.settings.preferredWebsite);
@@ -2482,20 +2481,20 @@ var BibleVersePlugin = class extends import_obsidian10.Plugin {
               await renderVerse(span, ref, cached, style, this.settings.preferredWebsite, this.settings.showAttribution, this.app, this, pb, vnL);
             } else {
               renderLink(span, ref, abbr, this.settings.preferredWebsite);
-              this.fetchAndRenderWithTranslation(span, ref, translationId, abbr, style, vnL, sVN, pb);
+              void this.fetchAndRenderWithTranslation(span, ref, translationId, abbr, style, vnL, sVN, pb);
             }
             frag.appendChild(span);
             if (this.settings.persistVerseText && translations.length === 0) {
-              this.handleBake(ctx, match[0], spec);
+              void this.handleBake(ctx, match[0], spec);
             }
           }
         } else {
-          frag.appendChild(document.createTextNode(match[0]));
+          frag.appendChild(activeDocument.createTextNode(match[0]));
         }
         lastIndex = matchIndex + match[0].length;
       }
       if (lastIndex < text.length) {
-        frag.appendChild(document.createTextNode(text.slice(lastIndex)));
+        frag.appendChild(activeDocument.createTextNode(text.slice(lastIndex)));
       }
       (_g = node2.parentNode) == null ? void 0 : _g.replaceChild(frag, node2);
     }
@@ -2696,7 +2695,7 @@ var BibleVersePlugin = class extends import_obsidian10.Plugin {
     return generateLink(ref, translationAbbr, this.settings.preferredWebsite);
   }
   onunload() {
-    document.body.style.removeProperty("--bible-verse-sidebar-top-padding");
+    activeDocument.body.style.removeProperty("--bible-verse-sidebar-top-padding");
   }
   /**
    * Force a refresh of all Live Preview widgets in all open editors.

--- a/src/api.ts
+++ b/src/api.ts
@@ -7,6 +7,12 @@ import { assembleChapterText, computeRequestedVerses } from "./format";
 
 const BASE_URL = "https://bible.helloao.org/api";
 
+/** Shape of the HelloAO chapter endpoint response we rely on. */
+interface HelloAoChapterResponse {
+  chapter: { content: unknown[] };
+  translation?: { licenseUrl?: string };
+}
+
 /**
  * Client for the HelloAO Bible API.
  * Fetches whole chapters and extracts specific verses client-side.
@@ -53,7 +59,7 @@ export class BibleApi {
       throw new Error(`HelloAO API returned status ${response.status}`);
     }
 
-    const data = response.json;
+    const data = response.json as HelloAoChapterResponse;
     const chapterContent: unknown[] = data.chapter.content;
     const requestedVerses = computeRequestedVerses(ref);
 

--- a/src/baker.ts
+++ b/src/baker.ts
@@ -1,6 +1,6 @@
-import { App, TFile } from "obsidian";
+import { App } from "obsidian";
 import { BibleReference, CachedVerse } from "./types";
-import { parseReference, formatReference, parseInlineSpec } from "./parser";
+import { parseReference, parseInlineSpec } from "./parser";
 
 /** Regex to find {ref} patterns in note source */
 const INLINE_REF_REGEX = /\{([A-Za-z0-9][^}\n]*)\}/g;
@@ -39,6 +39,18 @@ export interface InlineBakeOptions {
   url?: string;
 }
 
+/** A bakeable reference (inline token or ```bible block) located in note text. */
+export interface ExtractedReference {
+  raw: string;
+  ref: BibleReference | null;
+  offset: number;
+  type: "inline" | "block";
+  body?: string;
+  translations?: string[];
+  verseNewLine?: boolean | null;
+  showVerseNumbers?: boolean | null;
+}
+
 export class Baker {
   private app: App;
 
@@ -59,7 +71,7 @@ export class Baker {
     verseNewLine?: boolean | null;
     showVerseNumbers?: boolean | null;
   }[] {
-    const results: any[] = [];
+    const results: ExtractedReference[] = [];
     
     // 1. Find inline references (only if requested)
     if (includeInline) {
@@ -92,7 +104,7 @@ export class Baker {
         const ref = parseReference(lines[0].trim());
         
         // Parse config from block body
-        const config: any = {};
+        const config: Record<string, string | undefined> = {};
         for (let i = 1; i < lines.length; i++) {
           const line = lines[i].trim();
           const colonIdx = line.indexOf(":");
@@ -109,7 +121,7 @@ export class Baker {
           offset: match.index,
           type: "block",
           body: body,
-          translations: config.translation ? [config.translation] : (config.compare ? config.compare.split(",").map((s:any) => s.trim()) : []),
+          translations: config.translation ? [config.translation] : (config.compare ? config.compare.split(",").map((s) => s.trim()) : []),
           verseNewLine: config.newline !== undefined ? config.newline === "true" : null,
           showVerseNumbers: (config.numbers !== undefined || config["verse-numbers"] !== undefined) 
             ? (config.numbers ?? config["verse-numbers"]) === "true" 

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -39,7 +39,7 @@ export class VerseCache {
     for (const file of files.files) {
       try {
         const data = await adapter.read(file);
-        const entry: CachedVerse = JSON.parse(data);
+        const entry = JSON.parse(data) as CachedVerse;
         // Note: Old cache entries won't have the new naming scheme but will be
         // re-cached correctly when fetched. We'll derive the key from the filename
         // if possible, or just let it re-cache.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -292,7 +292,7 @@ export const HELLOAO_TRANSLATIONS: TranslationDef[] = [
  * Mapping from HelloAO translation ID → short display abbreviation.
  */
 export const HELLOAO_ABBREV: Record<string, string> = Object.fromEntries(
-  HELLOAO_TRANSLATIONS.map((t) => [t.id, t.abbreviation])
+  HELLOAO_TRANSLATIONS.map((t) => [t.id, t.abbreviation] as [string, string])
 );
 
 

--- a/src/inline-dom.ts
+++ b/src/inline-dom.ts
@@ -27,7 +27,7 @@ export function flattenInlineContent(container: HTMLElement, verseNewLine: boole
       container.insertBefore(p.firstChild, p);
     }
     if (i < paragraphs.length - 1) {
-      const sep = document.createElement("span");
+      const sep = activeDocument.createElement("span");
       sep.className = "bible-verse-para-break";
       container.insertBefore(sep, p);
     }
@@ -40,11 +40,11 @@ export function flattenInlineContent(container: HTMLElement, verseNewLine: boole
       (next as Text).data = (next as Text).data.slice(1);
     }
     if (verseNewLine) {
-      const lineBreak = document.createElement("span");
+      const lineBreak = activeDocument.createElement("span");
       lineBreak.className = "bible-verse-line-break";
       br.replaceWith(lineBreak);
     } else {
-      br.replaceWith(document.createTextNode(" "));
+      br.replaceWith(activeDocument.createTextNode(" "));
     }
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -168,7 +168,7 @@ export default class BibleVersePlugin extends Plugin {
           new Notice("No text selected.");
           return;
         }
-        navigator.clipboard.writeText(selection.trim());
+        void navigator.clipboard.writeText(selection.trim());
         new Notice("Copied to clipboard. Opening search...");
         const abbr = this.getTranslationAbbr();
         const url = generateSearchUrl(selection.trim(), abbr, this.settings.preferredWebsite);
@@ -212,11 +212,12 @@ export default class BibleVersePlugin extends Plugin {
   }
 
   async loadSettings(): Promise<void> {
-    this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+    const saved = (await this.loadData()) as Partial<BibleVerseSettings> | null;
+    this.settings = Object.assign({}, DEFAULT_SETTINGS, saved);
   }
 
   updateStyles(): void {
-    document.body.style.setProperty(
+    activeDocument.body.style.setProperty(
       "--bible-verse-sidebar-top-padding",
       `${this.settings.sidebarTopPadding}em`
     );
@@ -316,7 +317,7 @@ export default class BibleVersePlugin extends Plugin {
   ): Promise<void> {
     const INLINE_REGEX = /\{([A-Za-z0-9][^}\n]*)\}/g;
 
-    const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+    const walker = activeDocument.createTreeWalker(el, NodeFilter.SHOW_TEXT);
     const nodesToProcess: { node: Text; matches: RegExpMatchArray[] }[] = [];
 
     let node: Text | null;
@@ -330,13 +331,13 @@ export default class BibleVersePlugin extends Plugin {
 
     for (const { node, matches } of nodesToProcess) {
       const text = node.textContent || "";
-      const frag = document.createDocumentFragment();
+      const frag = activeDocument.createDocumentFragment();
       let lastIndex = 0;
 
       for (const match of matches) {
         const matchIndex = match.index!;
         if (matchIndex > lastIndex) {
-          frag.appendChild(document.createTextNode(text.slice(lastIndex, matchIndex)));
+          frag.appendChild(activeDocument.createTextNode(text.slice(lastIndex, matchIndex)));
         }
 
         const rawContent = match[1].trim();
@@ -344,7 +345,7 @@ export default class BibleVersePlugin extends Plugin {
 
         if (spec) {
           const { ref, translations } = spec;
-          const span = document.createElement("span");
+          const span = activeDocument.createElement("span");
           span.className = "bible-verse-container";
 
           const effectiveStyle = spec.styleOverride ?? this.settings.displayStyle;
@@ -354,15 +355,15 @@ export default class BibleVersePlugin extends Plugin {
           if (wantsBake && translations.length >= 2) {
             // Baking a side-by-side comparison isn't supported — render it live.
             new Notice("Bible Verse: baking isn't supported for multi-translation comparisons.");
-            this.renderInlineComparison(span, ref, translations, spec.paragraphBreaks ?? undefined);
+            void this.renderInlineComparison(span, ref, translations, spec.paragraphBreaks ?? undefined);
             frag.appendChild(span);
           } else if (wantsBake) {
             // Show a placeholder now; the bake rewrites the note on Reading-view render.
             renderBakePending(span, ref);
             frag.appendChild(span);
-            this.handleBake(ctx, match[0], spec, effectiveStyle === "native-callout" ? "callout" : "codeblock");
+            void this.handleBake(ctx, match[0], spec, effectiveStyle === "native-callout" ? "callout" : "codeblock");
           } else if (translations.length >= 2) {
-            this.renderInlineComparison(span, ref, translations, spec.paragraphBreaks ?? undefined);
+            void this.renderInlineComparison(span, ref, translations, spec.paragraphBreaks ?? undefined);
             frag.appendChild(span);
           } else if (translations.length === 1 && this.isTranslationLinkOnly(translations[0])) {
             renderLink(span, ref, translations[0].toUpperCase(), this.settings.preferredWebsite);
@@ -385,24 +386,24 @@ export default class BibleVersePlugin extends Plugin {
               await renderVerse(span, ref, cached, style, this.settings.preferredWebsite, this.settings.showAttribution, this.app, this, pb, vnL);
             } else {
               renderLink(span, ref, abbr, this.settings.preferredWebsite);
-              this.fetchAndRenderWithTranslation(span, ref, translationId, abbr, style, vnL, sVN, pb);
+              void this.fetchAndRenderWithTranslation(span, ref, translationId, abbr, style, vnL, sVN, pb);
             }
 
             frag.appendChild(span);
 
             if (this.settings.persistVerseText && translations.length === 0) {
-              this.handleBake(ctx, match[0], spec);
+              void this.handleBake(ctx, match[0], spec);
             }
           }
         } else {
-          frag.appendChild(document.createTextNode(match[0]));
+          frag.appendChild(activeDocument.createTextNode(match[0]));
         }
 
         lastIndex = matchIndex + match[0].length;
       }
 
       if (lastIndex < text.length) {
-        frag.appendChild(document.createTextNode(text.slice(lastIndex)));
+        frag.appendChild(activeDocument.createTextNode(text.slice(lastIndex)));
       }
 
       node.parentNode?.replaceChild(frag, node);
@@ -671,7 +672,7 @@ export default class BibleVersePlugin extends Plugin {
   }
 
   onunload(): void {
-    document.body.style.removeProperty("--bible-verse-sidebar-top-padding");
+    activeDocument.body.style.removeProperty("--bible-verse-sidebar-top-padding");
   }
 
   /**

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -10,6 +10,11 @@ export interface PassageSettings {
   paragraphBreaks: boolean;
 }
 
+/** Shape of the ESV passage-text endpoint response we rely on. */
+interface EsvPassageResponse {
+  passages?: string[];
+}
+
 /**
  * Fetch a passage from the ESV API (api.esv.org).
  * Requires a user-supplied API key.
@@ -32,8 +37,8 @@ export async function fetchEsvPassage(
     throw new Error(`ESV API returned status ${response.status}`);
   }
 
-  const data = response.json;
-  const passages: string[] = data.passages;
+  const data = response.json as EsvPassageResponse;
+  const passages = data.passages;
   if (!passages || passages.length === 0) {
     throw new Error(`No passages returned for ${refStr}`);
   }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -5,11 +5,11 @@ import { HELLOAO_TRANSLATIONS } from "./constants";
 import { addFeedbackSetting } from "./feedback";
 
 function df(text: string, ...examples: string[]): DocumentFragment {
-  const frag = document.createDocumentFragment();
-  frag.appendChild(document.createTextNode(text));
+  const frag = activeDocument.createDocumentFragment();
+  frag.appendChild(activeDocument.createTextNode(text));
   for (const ex of examples) {
-    frag.appendChild(document.createTextNode(" "));
-    const code = document.createElement("code");
+    frag.appendChild(activeDocument.createTextNode(" "));
+    const code = activeDocument.createElement("code");
     code.textContent = ex;
     frag.appendChild(code);
   }
@@ -108,7 +108,6 @@ export class BibleVerseSettingTab extends PluginSettingTab {
         slider
           .setLimits(0, 2, 0.1)
           .setValue(this.plugin.settings.sidebarTopPadding)
-          .setDynamicTooltip()
           .onChange(async (value) => {
             this.plugin.settings.sidebarTopPadding = value;
             await this.plugin.saveSettings();

--- a/src/view-plugin.ts
+++ b/src/view-plugin.ts
@@ -41,12 +41,10 @@ class BibleVerseWidget extends WidgetType {
   }
 
   toDOM(view: EditorView): HTMLElement {
-    const container = document.createElement("span");
+    const container = activeDocument.createElement("span");
     container.className = "bible-verse-livepreview";
 
     const vnL = this.spec.verseNewLine ?? this.spec.plugin.settings.verseNewLine;
-    const sVN = this.spec.showVerseNumbers ?? this.spec.plugin.settings.showVerseNumbers;
-    const pb = this.spec.paragraphBreaks ?? this.spec.plugin.settings.paragraphBreaks;
 
     // References that bake (the `bake` token or native-callout style) show a
     // placeholder in the editor; the actual bake happens on Reading-view render.
@@ -63,7 +61,7 @@ class BibleVerseWidget extends WidgetType {
 
     if (this.spec.translations.length >= 2) {
       if (this.spec.cachedVerses.length === this.spec.translations.length) {
-        renderComparison(
+        void renderComparison(
           container,
           this.spec.ref,
           this.spec.cachedVerses,
@@ -74,12 +72,12 @@ class BibleVerseWidget extends WidgetType {
         );
       } else {
         this.renderPill(container);
-        this.fetchAndUpdate(container, view);
+        void this.fetchAndUpdate(container, view);
       }
     } else {
       const cached = this.spec.cachedVerses[0];
       if (cached) {
-        renderVerse(
+        void renderVerse(
           container,
           this.spec.ref,
           cached,
@@ -93,7 +91,7 @@ class BibleVerseWidget extends WidgetType {
         );
       } else {
         this.renderPill(container);
-        this.fetchAndUpdate(container, view);
+        void this.fetchAndUpdate(container, view);
       }
     }
 
@@ -101,7 +99,7 @@ class BibleVerseWidget extends WidgetType {
   }
 
   private renderPill(container: HTMLElement): void {
-    const a = document.createElement("a");
+    const a = activeDocument.createElement("a");
     a.className = "bible-verse-pill";
     
     const iconSpan = a.createSpan({ cls: "bible-verse-icon" });

--- a/test/inline-dom.test.ts
+++ b/test/inline-dom.test.ts
@@ -2,6 +2,10 @@
 import { describe, it, expect } from "vitest";
 import { flattenInlineContent } from "../src/inline-dom";
 
+// The plugin uses Obsidian's `activeDocument` global (for popout-window support);
+// under jsdom we point it at the test document.
+(globalThis as unknown as { activeDocument: Document }).activeDocument = document;
+
 /**
  * Build a container populated as Obsidian's MarkdownRenderer would for inline
  * text: single "\n" separators become `<br>` followed by a "\n" text node;


### PR DESCRIPTION
## Summary

Cleans up the code-quality **Warnings** and code **Recommendations** from Obsidian's community-plugin review of 1.6.6. No behavior change — `npm run build` is clean and all **36 Vitest tests** stay green.

## Changes

- **`document` → `activeDocument`** (popout-window compatibility) across inline-dom.ts, main.ts, settings.ts, view-plugin.ts. The jsdom unit test stubs `activeDocument`.
- **Floating promises** — intentional fire-and-forget calls marked with `void` (main.ts, view-plugin.ts).
- **`no-unsafe-*` / `no-explicit-any`** — typed the boundaries where `any` entered:
  - interfaces for the HelloAO chapter and ESV passage JSON responses
  - `JSON.parse` / `loadData()` casts
  - tuple cast for `Object.fromEntries`
  - an `ExtractedReference` type + `Record<string, string | undefined>` config in the baker
- **Unused code** removed (`TFile`, `formatReference`, dead `sVN`/`pb`); deprecated **`setDynamicTooltip()`** removed.

## Deliberately not changed

- **`display()` deprecation** — migrating the settings tab to `getSettingDefinitions` is a large, higher-risk rewrite (and bumps min-app-version); left for a dedicated change.
- **Behavior "Recommendations"** — vault enumeration is the bake-vault commands; clipboard write is the "Search selection" command. Both are intended, legitimate uses.
- **Release name/notes warning** — process, not code: future releases should use the version as the title and include notes (the release workflow already titles by tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)