### PR TITLE
feat: make "Search selected text" work anywhere + document commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,14 @@ translation: KJV
 
 ### Commands
 
+Lookup & insert:
+
+- **Search Bible for selected text** — Select any text (in edit mode *or* Reading view) and run this to search your preferred Bible website for it. The selection is also copied to your clipboard.
+- **Quick insert reference** — Open a dialog to insert a `{reference}`, optionally opening it on your preferred Bible website at the same time.
+- **Open reference at cursor on Bible site** — Place the cursor on a `{ref}` while editing and run this to open that passage on your preferred Bible website. *(edit mode)*
+
+Baking & cache:
+
 - **Bake all verses in this note** — Fetch and embed all `{ref}` verses in the current note
 - **Refresh baked verses in this note** — Re-fetch and update all baked verses
 - **Refresh all baked verses in vault** — Re-fetch across all notes

--- a/main.js
+++ b/main.js
@@ -2300,16 +2300,21 @@ var BibleVersePlugin = class extends import_obsidian10.Plugin {
     this.addCommand({
       id: "search-selection",
       name: "Search Bible for selected text",
-      editorCallback: (editor) => {
-        const selection = editor.getSelection();
-        if (!selection || selection.trim().length === 0) {
+      // Plain callback (always listed in the palette). Reads the editor selection
+      // when editing, and falls back to the DOM selection so it also works in
+      // Reading view.
+      callback: () => {
+        var _a, _b, _c;
+        const editorSelection = (_b = (_a = this.app.workspace.activeEditor) == null ? void 0 : _a.editor) == null ? void 0 : _b.getSelection();
+        const selection = (editorSelection || ((_c = activeWindow.getSelection()) == null ? void 0 : _c.toString()) || "").trim();
+        if (selection.length === 0) {
           new import_obsidian10.Notice("No text selected.");
           return;
         }
-        void navigator.clipboard.writeText(selection.trim());
+        void navigator.clipboard.writeText(selection);
         new import_obsidian10.Notice("Copied to clipboard. Opening search...");
         const abbr = this.getTranslationAbbr();
-        const url = generateSearchUrl(selection.trim(), abbr, this.settings.preferredWebsite);
+        const url = generateSearchUrl(selection, abbr, this.settings.preferredWebsite);
         window.open(url, "_blank");
       }
     });

--- a/src/main.ts
+++ b/src/main.ts
@@ -162,16 +162,20 @@ export default class BibleVersePlugin extends Plugin {
     this.addCommand({
       id: "search-selection",
       name: "Search Bible for selected text",
-      editorCallback: (editor) => {
-        const selection = editor.getSelection();
-        if (!selection || selection.trim().length === 0) {
+      // Plain callback (always listed in the palette). Reads the editor selection
+      // when editing, and falls back to the DOM selection so it also works in
+      // Reading view.
+      callback: () => {
+        const editorSelection = this.app.workspace.activeEditor?.editor?.getSelection();
+        const selection = (editorSelection || activeWindow.getSelection()?.toString() || "").trim();
+        if (selection.length === 0) {
           new Notice("No text selected.");
           return;
         }
-        void navigator.clipboard.writeText(selection.trim());
+        void navigator.clipboard.writeText(selection);
         new Notice("Copied to clipboard. Opening search...");
         const abbr = this.getTranslationAbbr();
-        const url = generateSearchUrl(selection.trim(), abbr, this.settings.preferredWebsite);
+        const url = generateSearchUrl(selection, abbr, this.settings.preferredWebsite);
         window.open(url, "_blank");
       },
     });


### PR DESCRIPTION
## Why

The **"Search Bible for selected text"** command (search your preferred Bible site for a selection) seemed to vanish — it wasn't broken, but two things hid it:

1. It was an **`editorCallback`**, so Obsidian only lists it in the Ctrl-P palette while a note is **focused in edit mode**. In Reading view (or with focus elsewhere) Obsidian filters it out — so it "disappeared."
2. It was **undocumented** — not in the README's command list, so there was nothing to jog the memory.

## Changes

- **Command now works anywhere:** converted to a plain, always-listed command that reads the **editor** selection when editing and falls back to the **DOM** selection, so it also works in **Reading view**. (Edit-mode behavior is unchanged; this is strictly additive.)
- **README:** documented the three previously-undocumented interactive commands — *Search Bible for selected text*, *Quick insert reference*, and *Open reference at cursor* (partial progress on #11).

## Testing

- `npm run build` clean; `npm test` green (36 tests).
- Behavior to verify in-app: select text in **Reading view** → run the command → it searches your preferred site. (Edit-mode path already worked.)

## Note

Not in scope: a leftover orphaned `.claude/worktrees` directory on my machine makes vitest double-count tests locally — it's gitignored and doesn't affect the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)