### PR TITLE
fix: autocomplete brace/merge, \{} escaping, Source mode, numbered-book cursor

### DIFF
--- a/main.js
+++ b/main.js
@@ -645,6 +645,15 @@ var KNOWN_STYLES = [
 function isKnownStyle(token) {
   return KNOWN_STYLES.includes(token.toLowerCase());
 }
+function closingBraceState(restOfLine) {
+  if (restOfLine.startsWith("}"))
+    return "immediate";
+  const close = restOfLine.indexOf("}");
+  if (close === -1)
+    return "none";
+  const open = restOfLine.indexOf("{");
+  return open === -1 || close < open ? "later" : "none";
+}
 function parseInlineSpec(content) {
   const trimmed = content.trim();
   const simpleRef = parseReference(trimmed);
@@ -1050,6 +1059,8 @@ var Baker = class {
       let match2;
       const inlineRegex = new RegExp(INLINE_REF_REGEX.source, "g");
       while ((match2 = inlineRegex.exec(content)) !== null) {
+        if (match2.index > 0 && content[match2.index - 1] === "\\")
+          continue;
         const spec = parseInlineSpec(match2[1]);
         if (spec) {
           results.push({
@@ -1723,6 +1734,8 @@ var BibleReferenceSuggest = class extends import_obsidian7.EditorSuggest {
     const openBrace = beforeCursor.lastIndexOf("{");
     if (openBrace === -1)
       return null;
+    if (openBrace > 0 && line[openBrace - 1] === "\\")
+      return null;
     const afterOpen = beforeCursor.substring(openBrace + 1);
     if (afterOpen.includes("}"))
       return null;
@@ -1879,16 +1892,21 @@ var BibleReferenceSuggest = class extends import_obsidian7.EditorSuggest {
       return;
     const editor = context.editor;
     const line = editor.getLine(context.start.line);
-    const charAfterEnd = line[context.end.ch];
-    const hasClosingBrace = charAfterEnd === "}";
+    const braceState = closingBraceState(line.slice(context.end.ch));
     const isCompleteRef = /\d/.test(value);
     if (isCompleteRef) {
-      if (hasClosingBrace) {
+      if (braceState === "immediate") {
         editor.replaceRange(value, context.start, context.end);
         editor.setCursor({
           line: context.start.line,
           ch: context.start.ch + value.length + 1
           // +1 to land after the }
+        });
+      } else if (braceState === "later") {
+        editor.replaceRange(value, context.start, context.end);
+        editor.setCursor({
+          line: context.start.line,
+          ch: context.start.ch + value.length
         });
       } else {
         editor.replaceRange(value + "}", context.start, context.end);
@@ -2073,7 +2091,8 @@ function buildViewPlugin(plugin) {
         this.decorations = this.buildDecorations(view);
       }
       update(update) {
-        const needsRebuild = update.docChanged || update.viewportChanged || update.selectionSet || update.transactions.some(
+        const needsRebuild = update.docChanged || update.viewportChanged || update.selectionSet || // Live Preview <-> Source mode toggle (#27)
+        update.state.field(import_obsidian8.editorLivePreviewField) !== update.startState.field(import_obsidian8.editorLivePreviewField) || update.transactions.some(
           (tr) => tr.effects.some((e) => e.is(verseFetchedEffect))
         );
         if (needsRebuild) {
@@ -2081,6 +2100,9 @@ function buildViewPlugin(plugin) {
         }
       }
       buildDecorations(view) {
+        if (!view.state.field(import_obsidian8.editorLivePreviewField)) {
+          return import_view.Decoration.none;
+        }
         const builder = new import_state2.RangeSetBuilder();
         const selections = view.state.selection.ranges;
         for (const { from, to } of view.visibleRanges) {
@@ -2090,6 +2112,8 @@ function buildViewPlugin(plugin) {
           while ((match = INLINE_RE.exec(text)) !== null) {
             const tokenStart = from + match.index;
             const tokenEnd = tokenStart + match[0].length;
+            if (tokenStart > 0 && view.state.doc.sliceString(tokenStart - 1, tokenStart) === "\\")
+              continue;
             if (selectionOverlaps(selections, tokenStart, tokenEnd))
               continue;
             const content = match[1].trim();
@@ -2444,8 +2468,18 @@ var BibleVersePlugin = class extends import_obsidian10.Plugin {
    * Inline markdown postprocessor: finds {ref} in rendered text and replaces them.
    */
   async inlinePostProcessor(el, ctx) {
-    var _a, _b, _c, _d, _e, _f, _g;
+    var _a, _b, _c, _d, _e, _f, _g, _h, _i;
     const INLINE_REGEX = /\{([A-Za-z0-9][^}\n]*)\}/g;
+    const escapedBudget = /* @__PURE__ */ new Map();
+    const sectionInfo = ctx.getSectionInfo(el);
+    if (sectionInfo) {
+      const sectionSource = sectionInfo.text.split("\n").slice(sectionInfo.lineStart, sectionInfo.lineEnd + 1).join("\n");
+      const escapedRe = /\\(\{[A-Za-z0-9][^}\n]*\})/g;
+      let escMatch;
+      while ((escMatch = escapedRe.exec(sectionSource)) !== null) {
+        escapedBudget.set(escMatch[1], ((_a = escapedBudget.get(escMatch[1])) != null ? _a : 0) + 1);
+      }
+    }
     const walker = activeDocument.createTreeWalker(el, NodeFilter.SHOW_TEXT);
     const nodesToProcess = [];
     let node;
@@ -2465,24 +2499,31 @@ var BibleVersePlugin = class extends import_obsidian10.Plugin {
         if (matchIndex > lastIndex) {
           frag.appendChild(activeDocument.createTextNode(text.slice(lastIndex, matchIndex)));
         }
+        const escapesLeft = (_b = escapedBudget.get(match[0])) != null ? _b : 0;
+        if (escapesLeft > 0) {
+          escapedBudget.set(match[0], escapesLeft - 1);
+          frag.appendChild(activeDocument.createTextNode(match[0]));
+          lastIndex = matchIndex + match[0].length;
+          continue;
+        }
         const rawContent = match[1].trim();
         const spec = parseInlineSpec(rawContent);
         if (spec) {
           const { ref, translations } = spec;
           const span = activeDocument.createElement("span");
           span.className = "bible-verse-container";
-          const effectiveStyle = (_a = spec.styleOverride) != null ? _a : this.settings.displayStyle;
+          const effectiveStyle = (_c = spec.styleOverride) != null ? _c : this.settings.displayStyle;
           const wantsBake = spec.bake || effectiveStyle === "native-callout";
           if (wantsBake && translations.length >= 2) {
             new import_obsidian10.Notice("Bible Verse: baking isn't supported for multi-translation comparisons.");
-            void this.renderInlineComparison(span, ref, translations, (_b = spec.paragraphBreaks) != null ? _b : void 0);
+            void this.renderInlineComparison(span, ref, translations, (_d = spec.paragraphBreaks) != null ? _d : void 0);
             frag.appendChild(span);
           } else if (wantsBake) {
             renderBakePending(span, ref);
             frag.appendChild(span);
             void this.handleBake(ctx, match[0], spec, effectiveStyle === "native-callout" ? "callout" : "codeblock");
           } else if (translations.length >= 2) {
-            void this.renderInlineComparison(span, ref, translations, (_c = spec.paragraphBreaks) != null ? _c : void 0);
+            void this.renderInlineComparison(span, ref, translations, (_e = spec.paragraphBreaks) != null ? _e : void 0);
             frag.appendChild(span);
           } else if (translations.length === 1 && this.isTranslationLinkOnly(translations[0])) {
             renderLink(span, ref, translations[0].toUpperCase(), this.settings.preferredWebsite);
@@ -2491,9 +2532,9 @@ var BibleVersePlugin = class extends import_obsidian10.Plugin {
             const translationId = translations.length === 1 ? this.resolveTranslationId(translations[0]) : this.settings.defaultTranslation;
             const abbr = translations.length === 1 ? this.getTranslationAbbr(translationId) : this.getTranslationAbbr();
             const style = effectiveStyle;
-            const vnL = (_d = spec.verseNewLine) != null ? _d : this.settings.verseNewLine;
-            const sVN = (_e = spec.showVerseNumbers) != null ? _e : this.settings.showVerseNumbers;
-            const pb = (_f = spec.paragraphBreaks) != null ? _f : this.settings.paragraphBreaks;
+            const vnL = (_f = spec.verseNewLine) != null ? _f : this.settings.verseNewLine;
+            const sVN = (_g = spec.showVerseNumbers) != null ? _g : this.settings.showVerseNumbers;
+            const pb = (_h = spec.paragraphBreaks) != null ? _h : this.settings.paragraphBreaks;
             const cached = this.cache.get(abbr, formatReference(ref), vnL, sVN, pb);
             if (cached) {
               await renderVerse(span, ref, cached, style, this.settings.preferredWebsite, this.settings.showAttribution, this.app, this, pb, vnL);
@@ -2514,7 +2555,7 @@ var BibleVersePlugin = class extends import_obsidian10.Plugin {
       if (lastIndex < text.length) {
         frag.appendChild(activeDocument.createTextNode(text.slice(lastIndex)));
       }
-      (_g = node2.parentNode) == null ? void 0 : _g.replaceChild(frag, node2);
+      (_i = node2.parentNode) == null ? void 0 : _i.replaceChild(frag, node2);
     }
   }
   async fetchAndRenderWithTranslation(container, ref, translationId, translationAbbr, style, verseNewLineOverride, showVerseNumbersOverride, paragraphBreaksOverride) {

--- a/main.js
+++ b/main.js
@@ -654,6 +654,11 @@ function closingBraceState(restOfLine) {
   const open = restOfLine.indexOf("{");
   return open === -1 || close < open ? "later" : "none";
 }
+function mergeTokenRemainder(value, remainder) {
+  const valueParts = new Set(value.split(",").map((p) => p.trim().toLowerCase()));
+  const keep = remainder.split(",").map((p) => p.trim()).filter((p) => p.length > 0 && !valueParts.has(p.toLowerCase()));
+  return keep.length > 0 ? `${value}, ${keep.join(", ")}` : value;
+}
 function parseInlineSpec(content) {
   const trimmed = content.trim();
   const simpleRef = parseReference(trimmed);
@@ -1839,7 +1844,7 @@ var BibleReferenceSuggest = class extends import_obsidian7.EditorSuggest {
         }
       }
     }
-    return results.slice(0, this.limit).map((book) => ({ value: book }));
+    return results.slice(0, this.limit).map((book) => ({ value: book, isBook: true }));
   }
   /** Render a single suggestion row in the dropdown. */
   renderSuggestion(item, el) {
@@ -1893,7 +1898,7 @@ var BibleReferenceSuggest = class extends import_obsidian7.EditorSuggest {
     const editor = context.editor;
     const line = editor.getLine(context.start.line);
     const braceState = closingBraceState(line.slice(context.end.ch));
-    const isCompleteRef = /\d/.test(value);
+    const isCompleteRef = !item.isBook && /\d/.test(value);
     if (isCompleteRef) {
       if (braceState === "immediate") {
         editor.replaceRange(value, context.start, context.end);
@@ -1903,10 +1908,14 @@ var BibleReferenceSuggest = class extends import_obsidian7.EditorSuggest {
           // +1 to land after the }
         });
       } else if (braceState === "later") {
-        editor.replaceRange(value, context.start, context.end);
+        const closeCh = context.end.ch + line.slice(context.end.ch).indexOf("}");
+        const remainder = line.slice(context.end.ch, closeCh);
+        const merged = mergeTokenRemainder(value, remainder);
+        editor.replaceRange(merged, context.start, { line: context.start.line, ch: closeCh });
         editor.setCursor({
           line: context.start.line,
-          ch: context.start.ch + value.length
+          ch: context.start.ch + merged.length + 1
+          // land after the }
         });
       } else {
         editor.replaceRange(value + "}", context.start, context.end);

--- a/src/baker.ts
+++ b/src/baker.ts
@@ -89,6 +89,8 @@ export class Baker {
       let match;
       const inlineRegex = new RegExp(INLINE_REF_REGEX.source, "g");
       while ((match = inlineRegex.exec(content)) !== null) {
+        // Escaped token (\{...}) — literal text, never bake it (#28)
+        if (match.index > 0 && content[match.index - 1] === "\\") continue;
         const spec = parseInlineSpec(match[1]);
         if (spec) {
           results.push({

--- a/src/main.ts
+++ b/src/main.ts
@@ -321,6 +321,24 @@ export default class BibleVersePlugin extends Plugin {
   ): Promise<void> {
     const INLINE_REGEX = /\{([A-Za-z0-9][^}\n]*)\}/g;
 
+    // Markdown escaping consumes "\{" before rendering, so in the DOM an
+    // escaped token is indistinguishable from a live one. Read the section
+    // source and budget how many instances of each token string were escaped;
+    // that many matches are left as literal text below (#28).
+    const escapedBudget = new Map<string, number>();
+    const sectionInfo = ctx.getSectionInfo(el);
+    if (sectionInfo) {
+      const sectionSource = sectionInfo.text
+        .split("\n")
+        .slice(sectionInfo.lineStart, sectionInfo.lineEnd + 1)
+        .join("\n");
+      const escapedRe = /\\(\{[A-Za-z0-9][^}\n]*\})/g;
+      let escMatch: RegExpExecArray | null;
+      while ((escMatch = escapedRe.exec(sectionSource)) !== null) {
+        escapedBudget.set(escMatch[1], (escapedBudget.get(escMatch[1]) ?? 0) + 1);
+      }
+    }
+
     const walker = activeDocument.createTreeWalker(el, NodeFilter.SHOW_TEXT);
     const nodesToProcess: { node: Text; matches: RegExpMatchArray[] }[] = [];
 
@@ -342,6 +360,15 @@ export default class BibleVersePlugin extends Plugin {
         const matchIndex = match.index!;
         if (matchIndex > lastIndex) {
           frag.appendChild(activeDocument.createTextNode(text.slice(lastIndex, matchIndex)));
+        }
+
+        // Escaped in the source (\{...}) — keep it as literal text (#28)
+        const escapesLeft = escapedBudget.get(match[0]) ?? 0;
+        if (escapesLeft > 0) {
+          escapedBudget.set(match[0], escapesLeft - 1);
+          frag.appendChild(activeDocument.createTextNode(match[0]));
+          lastIndex = matchIndex + match[0].length;
+          continue;
         }
 
         const rawContent = match[1].trim();

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -173,6 +173,22 @@ export function closingBraceState(restOfLine: string): "immediate" | "later" | "
 }
 
 /**
+ * Merge an accepted suggestion with the leftover token text to its right
+ * (mid-token edits, #36). The remainder's comma-separated parts are appended
+ * to the suggestion, skipping empties and parts the suggestion already
+ * contains — so "…, inline, no-nl" + remainder "KJV" becomes
+ * "…, inline, no-nl, KJV", and an already-present "KJV" is not duplicated.
+ */
+export function mergeTokenRemainder(value: string, remainder: string): string {
+  const valueParts = new Set(value.split(",").map((p) => p.trim().toLowerCase()));
+  const keep = remainder
+    .split(",")
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0 && !valueParts.has(p.toLowerCase()));
+  return keep.length > 0 ? `${value}, ${keep.join(", ")}` : value;
+}
+
+/**
  * Parse the content inside {…} brackets into a structured spec.
  *
  * Supported formats (examples):

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -157,6 +157,22 @@ function isKnownStyle(token: string): token is DisplayStyle {
 }
 
 /**
+ * Classify the closing-brace situation for the text to the right of the cursor
+ * inside a {…} token (used by autocomplete insertion, #36):
+ *   "immediate" — the very next char is `}` (typical auto-pair; replace & skip)
+ *   "later"     — a `}` occurs before any `{`, so the token is already closed
+ *                 further right (mid-token edit; do NOT add another brace)
+ *   "none"      — no closing brace for this token; one must be appended
+ */
+export function closingBraceState(restOfLine: string): "immediate" | "later" | "none" {
+  if (restOfLine.startsWith("}")) return "immediate";
+  const close = restOfLine.indexOf("}");
+  if (close === -1) return "none";
+  const open = restOfLine.indexOf("{");
+  return open === -1 || close < open ? "later" : "none";
+}
+
+/**
  * Parse the content inside {…} brackets into a structured spec.
  *
  * Supported formats (examples):

--- a/src/suggest.ts
+++ b/src/suggest.ts
@@ -10,7 +10,7 @@ import {
 } from "obsidian";
 import type BibleVersePlugin from "./main";
 import { BOOK_ALIASES, USFM_CODES, HELLOAO_TRANSLATIONS } from "./constants";
-import { parseReference, formatReference, KNOWN_STYLES, parseInlineSpec } from "./parser";
+import { parseReference, formatReference, KNOWN_STYLES, parseInlineSpec, closingBraceState } from "./parser";
 
 interface BibleSuggestion {
   value: string;
@@ -57,6 +57,9 @@ export class BibleReferenceSuggest extends EditorSuggest<BibleSuggestion> {
     // Find the nearest unclosed { before the cursor
     const openBrace = beforeCursor.lastIndexOf("{");
     if (openBrace === -1) return null;
+
+    // Escaped token (\{...) — the user wants literal braces; stay quiet (#28)
+    if (openBrace > 0 && line[openBrace - 1] === "\\") return null;
 
     // If there is a } between { and cursor, the brace is already closed
     const afterOpen = beforeCursor.substring(openBrace + 1);
@@ -247,20 +250,28 @@ export class BibleReferenceSuggest extends EditorSuggest<BibleSuggestion> {
     const editor = context.editor;
     const line = editor.getLine(context.start.line);
 
-    // Check whether there is already a closing } immediately after the cursor
-    const charAfterEnd = line[context.end.ch];
-    const hasClosingBrace = charAfterEnd === "}";
+    // Classify the closing brace to the right of the cursor (#36): immediate
+    // (auto-pair), later on the line (mid-token edit), or absent.
+    const braceState = closingBraceState(line.slice(context.end.ch));
 
     const isCompleteRef = /\d/.test(value);
 
     if (isCompleteRef) {
       // Insert the formatted reference; handle the closing brace
-      if (hasClosingBrace) {
+      if (braceState === "immediate") {
         // Auto-paired } is already there — just replace content, skip past }
         editor.replaceRange(value, context.start, context.end);
         editor.setCursor({
           line: context.start.line,
           ch: context.start.ch + value.length + 1, // +1 to land after the }
+        });
+      } else if (braceState === "later") {
+        // The token is already closed further right (the user is editing
+        // mid-token) — never add a second brace; leave the cursor in place.
+        editor.replaceRange(value, context.start, context.end);
+        editor.setCursor({
+          line: context.start.line,
+          ch: context.start.ch + value.length,
         });
       } else {
         // No closing brace yet — add one

--- a/src/suggest.ts
+++ b/src/suggest.ts
@@ -10,11 +10,15 @@ import {
 } from "obsidian";
 import type BibleVersePlugin from "./main";
 import { BOOK_ALIASES, USFM_CODES, HELLOAO_TRANSLATIONS } from "./constants";
-import { parseReference, formatReference, KNOWN_STYLES, parseInlineSpec, closingBraceState } from "./parser";
+import { parseReference, formatReference, KNOWN_STYLES, parseInlineSpec, closingBraceState, mergeTokenRemainder } from "./parser";
 
 interface BibleSuggestion {
   value: string;
   label?: string;
+  /** True for book-name suggestions (insertion keeps the cursor inside the
+   * braces so the user can continue typing chapter:verse). Explicit flag —
+   * inferring from digits misclassifies numbered books like "1 Kings" (#23). */
+  isBook?: boolean;
 }
 
 /**
@@ -187,7 +191,7 @@ export class BibleReferenceSuggest extends EditorSuggest<BibleSuggestion> {
       }
     }
 
-    return results.slice(0, this.limit).map(book => ({ value: book }));
+    return results.slice(0, this.limit).map(book => ({ value: book, isBook: true }));
   }
 
   /** Render a single suggestion row in the dropdown. */
@@ -254,7 +258,9 @@ export class BibleReferenceSuggest extends EditorSuggest<BibleSuggestion> {
     // (auto-pair), later on the line (mid-token edit), or absent.
     const braceState = closingBraceState(line.slice(context.end.ch));
 
-    const isCompleteRef = /\d/.test(value);
+    // Book suggestions are flagged explicitly — testing the value for digits
+    // misclassifies numbered books ("1 Kings") as complete references (#23).
+    const isCompleteRef = !item.isBook && /\d/.test(value);
 
     if (isCompleteRef) {
       // Insert the formatted reference; handle the closing brace
@@ -266,12 +272,17 @@ export class BibleReferenceSuggest extends EditorSuggest<BibleSuggestion> {
           ch: context.start.ch + value.length + 1, // +1 to land after the }
         });
       } else if (braceState === "later") {
-        // The token is already closed further right (the user is editing
-        // mid-token) — never add a second brace; leave the cursor in place.
-        editor.replaceRange(value, context.start, context.end);
+        // The token is already closed further right (mid-token edit). Accept
+        // the suggestion, then re-attach the leftover token text (e.g. "KJV")
+        // comma-joined — never dropping it and never duplicating parts the
+        // suggestion already contains (#36).
+        const closeCh = context.end.ch + line.slice(context.end.ch).indexOf("}");
+        const remainder = line.slice(context.end.ch, closeCh);
+        const merged = mergeTokenRemainder(value, remainder);
+        editor.replaceRange(merged, context.start, { line: context.start.line, ch: closeCh });
         editor.setCursor({
           line: context.start.line,
-          ch: context.start.ch + value.length,
+          ch: context.start.ch + merged.length + 1, // land after the }
         });
       } else {
         // No closing brace yet — add one

--- a/src/view-plugin.ts
+++ b/src/view-plugin.ts
@@ -7,7 +7,7 @@ import {
   WidgetType,
 } from "@codemirror/view";
 import { RangeSetBuilder } from "@codemirror/state";
-import { setIcon } from "obsidian";
+import { setIcon, editorLivePreviewField } from "obsidian";
 import type BibleVersePlugin from "./main";
 import { parseInlineSpec, formatReference } from "./parser";
 import { BibleReference, CachedVerse, DisplayStyle, BibleWebsite } from "./types";
@@ -231,6 +231,8 @@ export function buildViewPlugin(plugin: BibleVersePlugin) {
           update.docChanged ||
           update.viewportChanged ||
           update.selectionSet ||
+          // Live Preview <-> Source mode toggle (#27)
+          update.state.field(editorLivePreviewField) !== update.startState.field(editorLivePreviewField) ||
           update.transactions.some((tr) =>
             tr.effects.some((e) => e.is(verseFetchedEffect))
           );
@@ -241,6 +243,11 @@ export function buildViewPlugin(plugin: BibleVersePlugin) {
       }
 
       buildDecorations(view: EditorView): DecorationSet {
+        // Source mode shows raw syntax — never replace {…} with widgets (#27)
+        if (!view.state.field(editorLivePreviewField)) {
+          return Decoration.none;
+        }
+
         const builder = new RangeSetBuilder<Decoration>();
         const selections = view.state.selection.ranges;
 
@@ -252,6 +259,9 @@ export function buildViewPlugin(plugin: BibleVersePlugin) {
           while ((match = INLINE_RE.exec(text)) !== null) {
             const tokenStart = from + match.index;
             const tokenEnd = tokenStart + match[0].length;
+
+            // Escaped token (\{...}) — leave it as literal text (#28)
+            if (tokenStart > 0 && view.state.doc.sliceString(tokenStart - 1, tokenStart) === "\\") continue;
 
             if (selectionOverlaps(selections, tokenStart, tokenEnd)) continue;
 

--- a/test/escape-and-braces.test.ts
+++ b/test/escape-and-braces.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { App } from "obsidian";
-import { closingBraceState } from "../src/parser";
+import { closingBraceState, mergeTokenRemainder } from "../src/parser";
 import { Baker } from "../src/baker";
 
 describe("closingBraceState (#36)", () => {
@@ -22,6 +22,38 @@ describe("closingBraceState (#36)", () => {
   it("none: no closing brace on the line", () => {
     expect(closingBraceState("")).toBe("none");
     expect(closingBraceState(" plain text")).toBe("none");
+  });
+});
+
+describe("mergeTokenRemainder (#36)", () => {
+  it("re-attaches the leftover token text, comma-joined (the repro)", () => {
+    // {1 Kings 1:1, inline, no|KJV} — accept "…, no-nl" with "KJV" remaining
+    expect(mergeTokenRemainder("1 Kings 1:1, inline, no-nl", "KJV")).toBe(
+      "1 Kings 1:1, inline, no-nl, KJV"
+    );
+  });
+
+  it("trims whitespace and leading commas in the remainder", () => {
+    expect(mergeTokenRemainder("John 3:16, nl", " KJV")).toBe("John 3:16, nl, KJV");
+    expect(mergeTokenRemainder("John 3:16, nl", ", KJV")).toBe("John 3:16, nl, KJV");
+  });
+
+  it("does not duplicate parts the suggestion already contains", () => {
+    // The KJVKJV case: suggestion already ends with KJV, remainder is KJV
+    expect(mergeTokenRemainder("1 Kings 1:1, inline, no-nl, KJV", "KJV")).toBe(
+      "1 Kings 1:1, inline, no-nl, KJV"
+    );
+  });
+
+  it("keeps multiple leftover parts", () => {
+    expect(mergeTokenRemainder("John 3:16, no-v", "KJV, callout")).toBe(
+      "John 3:16, no-v, KJV, callout"
+    );
+  });
+
+  it("empty/whitespace remainder leaves the value untouched", () => {
+    expect(mergeTokenRemainder("John 3:16, nl", "")).toBe("John 3:16, nl");
+    expect(mergeTokenRemainder("John 3:16, nl", "  ")).toBe("John 3:16, nl");
   });
 });
 

--- a/test/escape-and-braces.test.ts
+++ b/test/escape-and-braces.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import type { App } from "obsidian";
+import { closingBraceState } from "../src/parser";
+import { Baker } from "../src/baker";
+
+describe("closingBraceState (#36)", () => {
+  it("immediate: auto-paired brace right after cursor", () => {
+    expect(closingBraceState("}")).toBe("immediate");
+    expect(closingBraceState("} and more text")).toBe("immediate");
+  });
+
+  it("later: token already closed further right (mid-token edit)", () => {
+    // The #36 repro: cursor mid-token with ` KJV}` still ahead
+    expect(closingBraceState(" KJV}")).toBe("later");
+    expect(closingBraceState(", no-v} trailing")).toBe("later");
+  });
+
+  it("later only applies to the same token — a new { first means none", () => {
+    expect(closingBraceState(" text {John 3:16}")).toBe("none");
+  });
+
+  it("none: no closing brace on the line", () => {
+    expect(closingBraceState("")).toBe("none");
+    expect(closingBraceState(" plain text")).toBe("none");
+  });
+});
+
+describe("extractReferences ignores escaped tokens (#28)", () => {
+  const baker = new Baker(null as unknown as App);
+
+  it("skips \\{...} but keeps normal {...}", () => {
+    const content = "Literal: \\{John 3:16} and live: {John 3:17}";
+    const refs = baker.extractReferences(content, true);
+    expect(refs).toHaveLength(1);
+    expect(refs[0].raw).toBe("{John 3:17}");
+  });
+
+  it("extracts nothing when the only token is escaped", () => {
+    expect(baker.extractReferences("\\{Psalm 23}", true)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #39, which was merged mid-push and captured only the #37 (baked `nl`) fix — these two commits were stranded on the branch. Nothing new here beyond what was reviewed in the #39 description; this lands the remaining four bug fixes. **52/52 tests green**, all fixes verified live in Obsidian by the reporter.

## Contents

- **#36** — mid-token autocomplete: `closingBraceState()` prevents the doubled `}`; `mergeTokenRemainder()` completes the suggestion and re-attaches the leftover token text comma-joined (no clobbering, no duplication). `{1 Kings 1:1, inline, no|KJV}` + Enter on `…, no-nl` → `{1 Kings 1:1, inline, no-nl, KJV}`.
- **#23** — book suggestions carry an explicit `isBook` flag; the digit heuristic misclassified numbered books ("1 Kings") as complete references, parking the cursor outside the brace.
- **#28** — `\{John 3:16}` stays literal in Live Preview, Reading view (escaped-token budget via `ctx.getSectionInfo()`), the baker, and the suggester.
- **#27** — Source mode shows raw `{…}` syntax: no CM6 decorations when `editorLivePreviewField` is false, rebuild on mode toggle.

Fixes #36, fixes #28, fixes #27, fixes #23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)